### PR TITLE
Generate Swagger Clients from Specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 vendor
 bin
 build
+generated/
 
 all-cover.txt

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: ce00b3211bfa5352d77d82a4b8c899f3a5106a2eddfd530506d839362f7bb084
-updated: 2017-07-10T13:09:23.165775247-03:00
+hash: 9972c736c3c52acda0f2dbd2cd9d4ff85c9e310f3ad7b6f9b094ec5db64089b1
+updated: 2017-07-10T13:40:33.889493062-03:00
 imports:
 - name: github.com/alecthomas/gometalinter
   version: bae2f1293d092fd8167939d5108d1b025eaef9de
@@ -7,6 +7,10 @@ imports:
   version: d06ddd376b273047dca6e16eeeb2a2a8f9791978
   subpackages:
   - cmd/misspell
+- name: github.com/go-swagger/go-swagger
+  version: fbc64c262a833b40adf3d2cdba241fc4d30664b0
+  subpackages:
+  - cmd/swagger
 - name: github.com/golang/lint
   version: cb00e5669539f047b2f4c53a421a01b0c8e172c6
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -15,3 +15,6 @@ import:
 - package: golang.org/x/tools
   subpackages:
   - go/gcexportdata
+- package: github.com/go-swagger/go-swagger
+  subpackages:
+  - cmd/swagger

--- a/specs/billing.yaml
+++ b/specs/billing.yaml
@@ -1,0 +1,644 @@
+swagger: "2.0"
+info:
+  title: Billing API
+  description: |
+    # Introduction
+    The Billing API allows the Provisioning worker to construct
+    customer profiles, associate credit card information
+  version: 1.0.0
+host: api.billing.manifold.co
+schemes:
+- https
+produces:
+- application/json
+consumes:
+- application/json
+securityDefinitions:
+  jwtRequired:
+    type: apiKey
+    description: Authentication mechanism for dashboard users
+    name: Authorization
+    in: header
+responses:
+  BadRequest:
+    description: Request denied due to invalid request body, path, or headers.
+    schema:
+      $ref: '#/definitions/Error'
+    examples:
+      application/json:
+        type: bad_request
+        message:
+        - Invalid Profile ID Provided
+  Conflict:
+    description: Request denied due to conflict with existing data.
+    schema:
+      $ref: '#/definitions/Error'
+  Unauthorized:
+    description: Request denied as the provided credentials are no longer valid.
+    schema:
+      $ref: '#/definitions/Error'
+    examples:
+      application/json:
+        type: unauthorized
+        message:
+        - ""
+  NotFound:
+    description: Request denied as the requested profile does not exist.
+    schema:
+      $ref: '#/definitions/Error'
+    examples:
+      application/json:
+        type: not_found
+        message:
+        - Cannot modify billing for another user
+  Internal:
+    description: Request failed due to an internal server error.
+    schema:
+      $ref: '#/definitions/Error'
+    examples:
+      application/json:
+        type: internal
+        message:
+        - Internal Server Error
+security:
+- jwtRequired: []
+basePath: /v1
+paths:
+  /profiles:
+    x-manifold-audience: browser
+    post:
+      summary: Create Billing Profile
+      description: |
+        Creates a new billing profile for the authenticated user, under which
+        their credit card is associated.
+      tags:
+      - Profile
+      parameters:
+      - name: body
+        in: body
+        description: Billing Profile Create Request Body
+        required: true
+        schema:
+          $ref: '#/definitions/ProfileCreateRequest'
+      responses:
+        201:
+          description: A billing profile
+          schema:
+            $ref: '#/definitions/BillingProfile'
+        400:
+          $ref: '#/responses/BadRequest'
+        401:
+          $ref: '#/responses/Unauthorized'
+        500:
+          $ref: '#/responses/Internal'
+  /profiles/{id}:
+    x-manifold-audience: browser
+    get:
+      summary: Retrieve Billing Profile
+      description: |
+        Retrieves the billing profile and associated detail of the authenticated user
+      tags:
+      - Profile
+      parameters:
+      - name: id
+        in: path
+        description: |
+          ID of the user to retrieve, stored as a base32 encoded 18 byte
+          identifier.
+        required: true
+        type: string
+        pattern: ^[0-9abcdefghjkmnpqrtuvwxyz]{29}$
+        format: base32ID
+      responses:
+        200:
+          description: A billing profile
+          schema:
+            $ref: '#/definitions/BillingProfile'
+        400:
+          $ref: '#/responses/BadRequest'
+        401:
+          $ref: '#/responses/Unauthorized'
+        404:
+          $ref: '#/responses/NotFound'
+        500:
+          $ref: '#/responses/Internal'
+    patch:
+      summary: Update Billing Profile
+      description: |
+        Replaces the billing profile's source of funds with the credit card supplied
+      tags:
+      - Profile
+      parameters:
+      - name: id
+        in: path
+        description: |
+          ID of the user to update, stored as a base32 encoded 18 byte
+          identifier.
+        required: true
+        type: string
+        pattern: ^[0-9abcdefghjkmnpqrtuvwxyz]{29}$
+        format: base32ID
+      - name: body
+        in: body
+        description: Billing Profile Update Request Body
+        required: true
+        schema:
+          $ref: '#/definitions/ProfileUpdateRequest'
+      responses:
+        200:
+          description: Billing profile which has been updated
+          schema:
+            $ref: '#/definitions/BillingProfile'
+        400:
+          $ref: '#/responses/BadRequest'
+        401:
+          $ref: '#/responses/Unauthorized'
+        404:
+          $ref: '#/responses/NotFound'
+        500:
+          $ref: '#/responses/Internal'
+  /discounts:
+    x-manifold-audience: browser
+    post:
+      summary: Apply a coupon code to a user's account
+      description: |
+        Applies the provided coupon code to a user's account, converting it to
+        a discount/credit.
+      tags:
+      - Discount
+      parameters:
+      - name: body
+        in: body
+        description: Coupon details
+        required: true
+        schema:
+          $ref: '#/definitions/DiscountCreateRequest'
+      responses:
+        201:
+          description: The created subscription event for this discount
+          schema:
+            $ref: '#/definitions/SubscriptionEvent'
+        400:
+          $ref: '#/responses/BadRequest'
+        401:
+          $ref: '#/responses/Unauthorized'
+        500:
+          $ref: '#/responses/Internal'
+  /subscription-events:
+    x-manifold-audience: browser
+    get:
+      summary: List subscription events
+      description: |
+        List the historical subscription events for a user. Events are sorted by
+        `body.event_number`, in increasing order.
+
+        Subscription events are the authoratative log of all actions for an
+        account that affect billing. Each event references the event that
+        preceeded it, and all events are cryptographically signed by Manifold,
+        so that any tampering can be detected.
+
+        ## Calculating Coupon and Credit Balance
+
+        Subscription events with `body.event_type` of `credit` can be coupon
+        applications, or general credits applied by Manifold to an account.
+        Credits that came from a coupon will have both `body.coupon_id` and
+        `body.code` set. As coupon codes may be reused by Manifold,
+        `body.coupon_id` must be used for determining the remaining balance on
+        a coupon application in subsequent billing periods (see below).
+
+        When a coupon is first applied, `body.amount` holds the full value of
+        the coupon in cents. As subsequent billing periods occur, new
+        subscription events are added to the list with the updated remaining
+        credit balance. These events will have `body.rollover_id` set to the id
+        of the previous `credit` subscription event in the list that  maps to
+        the same coupon application.
+
+        If a credit balance is zero at the end of a billing period, no new
+        rollover subscription event is added. If the current time in UTC is the
+        second of the month (to allow for some processing delay), and there is
+        no new rollover subscription event in the list, a coupon application can
+        be considered to have a zero balance, and be fully used in the previous
+        billing period.
+      tags:
+      - Subscription
+      parameters:
+      - name: event_type
+        in: query
+        description: Filter returned events by type. Only `credit` is supported.
+        required: true
+        type: string
+        enum:
+        - credit
+      responses:
+        200:
+          description: The list of subscription events, ordered by event number.
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/SubscriptionEvent'
+        400:
+          $ref: '#/responses/BadRequest'
+        401:
+          $ref: '#/responses/Unauthorized'
+        500:
+          $ref: '#/responses/Internal'
+definitions:
+  ID:
+    type: string
+    description: A base32 encoded 18 byte identifier.
+    pattern: ^[0-9abcdefghjkmnpqrtuvwxyz]{29}$
+    format: base32ID
+    x-go-type:
+      type: ID
+      import:
+        package: github.com/manifoldco/go-manifold
+        alias: manifold
+  Base64:
+    type: string
+    description: A base64 encoded binary value.
+    pattern: ^[a-zA-Z0-9_-]*$
+    format: base64
+  Error:
+    type: object
+    properties:
+      type:
+        type: string
+        enum:
+        - bad_request
+        - unauthorized
+        - not_found
+        - internal
+        description: The error type
+      message:
+        type: array
+        description: Explanation of the errors
+        items:
+          type: string
+    x-go-type:
+      type: Error
+      import:
+        package: github.com/manifoldco/go-manifold
+        alias: manifold
+  BillingSubDelete:
+    description: |
+      Infomation necessary to cancel a subscription item
+    type: object
+    properties:
+      operation_id:
+        $ref: '#/definitions/ID'
+      occurred_at:
+        type: string
+        format: date-time
+    additionalProperties: false
+    required:
+    - operation_id
+    - occurred_at
+  BillingCreditCreate:
+    description: |
+      Information necessary to create a new credit
+    type: object
+    properties:
+      provider_id:
+        $ref: '#/definitions/ID'
+      resource_id:
+        $ref: '#/definitions/ID'
+      operation_id:
+        $ref: '#/definitions/ID'
+      occurred_at:
+        type: string
+        format: date-time
+      reason:
+        type: string
+        maxLength: 64
+      amount:
+        type: integer
+        minimum: 0
+        description: Dollar value in cents
+    additionalProperties: false
+    required:
+    - operation_id
+    - occurred_at
+  CouponCode:
+    description: Alphanumeric coupon code
+    type: string
+    minLength: 1
+    maxLength: 128
+    pattern: ^[0-9A-Z]{1,128}$
+  BillingCouponCreate:
+    description: Information necessary to create a new coupon
+    type: object
+    properties:
+      type:
+        type: string
+        enum:
+        - standard
+        - signup
+      provider_id:
+        $ref: '#/definitions/ID'
+      expires_at:
+        description: |
+          Expiry datetime for this coupon. If omitted, the coupon does not
+          expire.
+        type: string
+        format: date-time
+      total:
+        description: |
+          Total claimable codes for this coupon. If omitted, there are infinite
+          coupons.
+        type: integer
+        minimum: 1
+      code:
+        $ref: '#/definitions/CouponCode'
+      amount:
+        description: Dollar value in cents
+        type: integer
+        minimum: 0
+    additionalProperties: false
+    required:
+    - type
+    - code
+    - amount
+  BillingSubCreate:
+    description: |
+      Information necessary to create a new subscription item
+    type: object
+    properties:
+      plan_id:
+        $ref: '#/definitions/ID'
+      operation_id:
+        $ref: '#/definitions/ID'
+      occurred_at:
+        type: string
+        format: date-time
+    additionalProperties: false
+    required:
+    - operation_id
+    - occurred_at
+    - plan_id
+  PayoutProfile:
+    description: |
+      Association of a provider with a billing account
+    type: object
+    properties:
+      id:
+        $ref: '#/definitions/ID'
+      version:
+        type: integer
+        enum:
+        - 1
+      type:
+        type: string
+        enum:
+        - payout_profile
+      body:
+        type: object
+        properties:
+          provider_id:
+            $ref: '#/definitions/ID'
+          account_id:
+            type: string
+        additionalProperties: false
+        required:
+        - user_id
+        - account_id
+    additionalProperties: false
+    required:
+    - id
+    - type
+    - version
+    - body
+  PayoutProfileCreateRequest:
+    type: object
+    properties:
+      token:
+        type: string
+        minLength: 3
+        maxLength: 64
+        description: |
+          Tokenized destination of funds
+      provider_id:
+        $ref: '#/definitions/ID'
+      account:
+        $ref: '#/definitions/StripeAccount'
+      legal_entity:
+        $ref: '#/definitions/StripeLegalEntity'
+    required:
+    - provider_id
+    - account
+    - legal_entity
+    - token
+    additionalProperties: false
+  StripeLegalEntity:
+    type: object
+  StripeAccount:
+    type: object
+    properties:
+      email:
+        $ref: '#/definitions/Email'
+      business_name:
+        type: string
+        minLength: 1
+      country:
+        type: string
+        minLength: 2
+        maxLength: 2
+    required:
+    - email
+    - business_name
+    - country
+  BillingProfile:
+    description: |
+      Details of a billing profile
+    type: object
+    properties:
+      id:
+        $ref: '#/definitions/ID'
+      version:
+        type: integer
+        enum:
+        - 1
+      type:
+        type: string
+        enum:
+        - billing_profile
+      body:
+        type: object
+        properties:
+          user_id:
+            $ref: '#/definitions/ID'
+          sources:
+            type: array
+            items:
+              $ref: '#/definitions/Source'
+        required:
+        - user_id
+        - sources
+    additionalProperties: false
+    required:
+    - id
+    - type
+    - version
+    - body
+  ProfileCreateRequest:
+    type: object
+    properties:
+      user_id:
+        $ref: '#/definitions/ID'
+      token:
+        type: string
+        minLength: 3
+        maxLength: 64
+        description: |
+          Tokenized source of funds
+    required:
+    - user_id
+    - token
+    additionalProperties: false
+  ProfileUpdateRequest:
+    type: object
+    properties:
+      token:
+        type: string
+        minLength: 3
+        maxLength: 64
+        description: |
+          Tokenized source of funds
+    required:
+    - token
+    additionalProperties: false
+  Source:
+    type: object
+    properties:
+      name:
+        type: string
+      country:
+        type: string
+      zip:
+        type: string
+      last_four:
+        type: string
+      exp_month:
+        type: integer
+      exp_year:
+        type: integer
+      brand:
+        type: string
+        enum:
+        - Unknown
+        - Visa
+        - American Express
+        - MasterCard
+        - Discover
+        - JCB
+        - Diners Club
+    additionalProperties: false
+    required:
+    - name
+    - country
+    - last_four
+    - exp_month
+    - exp_year
+  Email:
+    type: string
+    format: email
+    x-nullable: true
+    x-go-type:
+      type: Email
+      import:
+        package: github.com/manifoldco/go-manifold
+        alias: manifold
+  DiscountCreateRequest:
+    type: object
+    properties:
+      code:
+        $ref: '#/definitions/CouponCode'
+    required:
+    - code
+    additionalProperties: false
+  SubscriptionEvent:
+    type: object
+    properties:
+      id:
+        $ref: '#/definitions/ID'
+      version:
+        type: integer
+        enum:
+        - 1
+      type:
+        type: string
+        enum:
+        - subscription_event
+      body:
+        $ref: '#/definitions/SubscriptionEventBody'
+      signature:
+        type: object
+        properties:
+          alg:
+            type: string
+            enum:
+            - eddsa
+          value:
+            $ref: '#/definitions/Base64'
+          public_key:
+            $ref: '#/definitions/Base64'
+          endorsement:
+            $ref: '#/definitions/Base64'
+    x-go-type:
+      type: SubscriptionEvent
+      import:
+        package: github.com/manifoldco/marketplace/billing/primitives
+  SubscriptionEventBody:
+    type: object
+    discriminator: event_type
+    properties:
+      event_type:
+        type: string
+      event_number:
+        type: integer
+        minimum: 0
+      parent_event:
+        $ref: '#/definitions/ID'
+      operation_id:
+        $ref: '#/definitions/ID'
+      occurred_at:
+        type: string
+        format: date-time
+      user_id:
+        $ref: '#/definitions/ID'
+      provider_id:
+        $ref: '#/definitions/ID'
+      resource_id:
+        $ref: '#/definitions/ID'
+      rollover_id:
+        $ref: '#/definitions/ID'
+    additionalProperties: false
+    required:
+    - event_type
+    - event_number
+    - user_id
+    - operation_id
+    - occurred_at
+  credit:
+    type: object
+    allOf:
+    - $ref: '#/definitions/SubscriptionEventBody'
+    - type: object
+      properties:
+        amount:
+          type: integer
+          minimum: 0
+          description: Dollar value of credit in cents
+        currency:
+          type: string
+          enum:
+          - usd
+        reason:
+          type: string
+        coupon_id:
+          $ref: '#/definitions/ID'
+        code:
+          $ref: '#/definitions/CouponCode'
+      required:
+      - amount
+      - currency
+      - reason

--- a/specs/catalog.yaml
+++ b/specs/catalog.yaml
@@ -1,0 +1,698 @@
+swagger: "2.0"
+info:
+  title: Catalog API
+  description: Access Regions, Providers, Products and Plans
+  version: 1.0.0
+host: api.catalog.manifold.co
+schemes:
+- https
+produces:
+- application/json
+consumes:
+- application/json
+basePath: /v1
+paths:
+  /regions/:
+    get:
+      summary: List all available regions
+      tags:
+      - Region
+      parameters:
+      - name: location
+        in: query
+        description: |
+          Filter results to only include the regions that have this location.
+        type: string
+        format: label
+        pattern: ^[a-z0-9][a-z0-9\-\_]{1,128}$
+      - name: platform
+        in: query
+        description: |
+          Filter results to only include the regions that are on this
+          platform.
+        type: string
+        format: label
+        pattern: ^[a-z0-9][a-z0-9\-\_]{1,128}$
+      responses:
+        200:
+          description: A list of regions.
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Region'
+        500:
+          description: Unexpected Error
+          schema:
+            $ref: '#/definitions/Error'
+  /regions/{id}:
+    get:
+      summary: Get a Region by ID
+      parameters:
+      - name: id
+        in: path
+        description: ID of the region to lookup, stored as a base32 encoded 18 byte
+          identifier.
+        required: true
+        type: string
+        pattern: ^[0-9abcdefghjkmnpqrtuvwxyz]{29}$
+        format: base32ID
+      tags:
+      - Region
+      responses:
+        200:
+          description: A region.
+          schema:
+            $ref: '#/definitions/Region'
+        400:
+          description: Provided Region ID is Invalid
+          schema:
+            $ref: '#/definitions/Error'
+        404:
+          description: Region could not be found
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Unexpected Error
+          schema:
+            $ref: '#/definitions/Error'
+  /providers/:
+    get:
+      summary: List all available providers
+      tags:
+      - Provider
+      parameters:
+      - $ref: '#/parameters/LabelFilter'
+      responses:
+        200:
+          description: A list of providers.
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Provider'
+        500:
+          description: Unexpected Error
+          schema:
+            $ref: '#/definitions/Error'
+  /providers/{id}:
+    get:
+      summary: Get a provider by ID
+      parameters:
+      - name: id
+        in: path
+        description: ID of the provider to lookup, stored as a base32 encoded 18 byte
+          identifier.
+        required: true
+        type: string
+        pattern: ^[0-9abcdefghjkmnpqrtuvwxyz]{29}$
+        format: base32ID
+      tags:
+      - Provider
+      responses:
+        200:
+          description: A provider.
+          schema:
+            $ref: '#/definitions/Provider'
+        404:
+          description: Unknown provider error
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Unexpected Error
+          schema:
+            $ref: '#/definitions/Error'
+  /products/:
+    get:
+      summary: List all available products
+      parameters:
+      - $ref: '#/parameters/Authorization'
+      - name: provider_id
+        in: query
+        description: |
+          Base32 encoded 18 byte identifier of the provider that these
+          products must belong to.
+        type: string
+        pattern: ^[0-9abcdefghjkmnpqrtuvwxyz]{29}$
+        format: base32ID
+      - $ref: '#/parameters/LabelFilter'
+      tags:
+      - Product
+      responses:
+        200:
+          description: A product.
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Product'
+        400:
+          description: Invalid provider_id supplied
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Unexpected Error
+          schema:
+            $ref: '#/definitions/Error'
+  /products/{id}:
+    get:
+      summary: Get a product by ID
+      parameters:
+      - $ref: '#/parameters/Authorization'
+      - name: id
+        in: path
+        description: |
+          ID of the product to lookup, stored as a base32 encoded 18 byte
+          identifier.
+        required: true
+        type: string
+        pattern: ^[0-9abcdefghjkmnpqrtuvwxyz]{29}$
+        format: base32ID
+      tags:
+      - Product
+      responses:
+        200:
+          description: A product.
+          schema:
+            $ref: '#/definitions/Product'
+        400:
+          description: Invalid Product ID
+          schema:
+            $ref: '#/definitions/Error'
+        404:
+          description: Product not found error
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /plans/{id}:
+    get:
+      summary: Get a plan by ID
+      parameters:
+      - $ref: '#/parameters/Authorization'
+      - name: id
+        in: path
+        description: |
+          ID of the plan to lookup, stored as a base32 encoded 18 byte
+          identifier.
+        required: true
+        type: string
+        pattern: ^[0-9abcdefghjkmnpqrtuvwxyz]{29}$
+        format: base32ID
+      tags:
+      - Plan
+      responses:
+        200:
+          description: A plan.
+          schema:
+            $ref: '#/definitions/Plan'
+        400:
+          description: Invalid Plan ID Provided
+          schema:
+            $ref: '#/definitions/Error'
+        404:
+          description: Unknown plan error
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /plans/:
+    get:
+      summary: Get a list of plans.
+      parameters:
+      - $ref: '#/parameters/Authorization'
+      - name: product_id
+        in: query
+        description: Return the plans that are associated with this product.
+        required: true
+        type: array
+        collectionFormat: multi
+        items:
+          format: base32ID
+          type: string
+      - $ref: '#/parameters/LabelFilter'
+      tags:
+      - Plan
+      responses:
+        200:
+          description: A list of plans for the given product.
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Plan'
+        400:
+          description: Invalid Parameters Provided
+          schema:
+            $ref: '#/definitions/Error'
+        404:
+          description: Could not find product
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+parameters:
+  Authorization:
+    name: Authorization
+    in: header
+    description: |
+      This header authenticates the request.
+    type: string
+  LabelFilter:
+    name: label
+    in: query
+    description: |
+      Filter results to only include those that have this label.
+    type: string
+    format: label
+    pattern: ^[a-z0-9][a-z0-9\-\_]{1,128}$
+definitions:
+  ID:
+    type: string
+    description: A base32 encoded 18 byte identifier.
+    pattern: ^[0-9abcdefghjkmnpqrtuvwxyz]{29}$
+    format: base32ID
+    x-go-type:
+      type: ID
+      import:
+        package: github.com/manifoldco/go-manifold
+        alias: manifold
+  Label:
+    type: string
+    description: A machine readable unique label, which is url safe.
+    pattern: ^[a-z0-9][a-z0-9\-\_]{1,128}$
+    x-go-type:
+      type: Label
+      import:
+        package: github.com/manifoldco/go-manifold
+        alias: manifold
+  Name:
+    type: string
+    description: A name of an entity which is displayed to a human.
+    pattern: ^[a-zA-Z][a-z0-9A-Z \-]{2,128}$
+    x-go-type:
+      type: Name
+      import:
+        package: github.com/manifoldco/go-manifold
+        alias: manifold
+  LogoURL:
+    type: string
+    description: |
+      Logo used for Provider and Product listings.
+
+      Must be square (same width and height) and minimum 400px. Maximum of 800px.
+    format: url
+    pattern: ^cdn\.(?:stage\.)?manifold.co
+  Region:
+    type: object
+    properties:
+      id:
+        $ref: '#/definitions/ID'
+      type:
+        type: string
+        enum:
+        - region
+      version:
+        type: integer
+        enum:
+        - 1
+      body:
+        type: object
+        properties:
+          platform:
+            type: string
+            enum:
+            - aws
+          location:
+            type: string
+            enum:
+            - us-east-1
+          name:
+            $ref: '#/definitions/Name'
+          priority:
+            type: number
+            multipleOf: 1
+            minimum: 0
+            maximum: 100
+            x-nullable: false
+        additionalProperties: false
+        required:
+        - platform
+        - location
+        - name
+        - priority
+    additionalProperties: false
+    required:
+    - id
+    - type
+    - version
+    - body
+  Provider:
+    type: object
+    properties:
+      id:
+        $ref: '#/definitions/ID'
+      version:
+        type: integer
+        enum:
+        - 1
+      type:
+        type: string
+        enum:
+        - provider
+      body:
+        type: object
+        properties:
+          label:
+            $ref: '#/definitions/Label'
+          name:
+            $ref: '#/definitions/Name'
+          logo_url:
+            $ref: '#/definitions/LogoURL'
+          support_email:
+            type: string
+            format: email
+            x-nullable: false
+          documentation_url:
+            type: string
+            format: url
+        additionalProperties: false
+        required:
+        - label
+        - name
+    additionalProperties: false
+    required:
+    - id
+    - version
+    - type
+    - body
+  FeatureType:
+    description: |
+      A feature type represents the different aspects of a product that are
+      offered, these features can manifest differently depending on the plan.
+    type: object
+    properties:
+      label:
+        $ref: '#/definitions/Label'
+      name:
+        $ref: '#/definitions/Name'
+      type:
+        type: string
+        enum:
+        - boolean
+        - string
+        - number
+    additionalProperties: false
+    required:
+    - label
+    - name
+    - type
+  FeatureValue:
+    type: object
+    properties:
+      feature:
+        $ref: '#/definitions/Label'
+      value:
+        type: string
+    additionalProperties: false
+    required:
+    - feature
+    - value
+  ValueProp:
+    type: object
+    properties:
+      header:
+        description: Heading of a value proposition.
+        type: string
+        minLength: 10
+        maxLength: 80
+        x-nullable: false
+      body:
+        description: Body of a value proposition.
+        type: string
+        minLength: 10
+        maxLength: 200
+        x-nullable: false
+    additionalProperties: false
+    required:
+    - header
+    - body
+  ProductImageURL:
+    type: string
+    description: |
+      Image URL used for Product listings.
+
+      Minimum 660px wide, 400px high.
+    format: url
+    pattern: ^cdn\.(?:stage\.)?manifold.co
+  Product:
+    type: object
+    properties:
+      id:
+        $ref: '#/definitions/ID'
+      version:
+        type: integer
+        enum:
+        - 1
+      type:
+        type: string
+        enum:
+        - product
+      body:
+        type: object
+        properties:
+          provider_id:
+            $ref: '#/definitions/ID'
+          label:
+            $ref: '#/definitions/Label'
+            description: |
+              Product labels are globally unique and contain the provider name.
+          name:
+            $ref: '#/definitions/Name'
+          state:
+            type: string
+            enum:
+            - available
+            - hidden
+            - grandfathered
+          logo_url:
+            $ref: '#/definitions/LogoURL'
+          tagline:
+            description: |
+              140 character sentence positioning the product.
+            type: string
+            maxLength: 140
+            x-nullable: false
+          value_props:
+            description: A list of value propositions of the product.
+            type: array
+            items:
+              $ref: '#/definitions/ValueProp'
+            maxItems: 8
+            x-nullable: false
+          images:
+            type: array
+            items:
+              $ref: '#/definitions/ProductImageURL'
+            maxItems: 8
+            x-nullable: false
+          support_email:
+            type: string
+            format: email
+            x-nullable: false
+          documentation_url:
+            type: string
+            format: url
+          terms:
+            description: |
+              URL to this Product's Terms of Service. If provided is true, then
+              a url must be set. Otherwise, provided is false.
+            type: object
+            properties:
+              url:
+                type: string
+                format: url
+              provided:
+                type: boolean
+                x-nullable: false
+            additionalProperties: false
+            required:
+            - url
+            - provided
+          feature_types:
+            type: array
+            items:
+              $ref: '#/definitions/FeatureType'
+          billing:
+            type: object
+            properties:
+              type:
+                type: string
+                enum:
+                - monthly-prorated
+              currency:
+                type: string
+                enum:
+                - usd
+            additionalProperties: false
+            required:
+            - type
+            - currency
+          integration:
+            type: object
+            properties:
+              base_url:
+                type: string
+                format: url
+              sso_url:
+                type: string
+                format: url
+              version:
+                type: string
+                enum:
+                - v1
+              features:
+                type: object
+                properties:
+                  sso:
+                    description: |
+                      Represents whether or not this product supports Single
+                      Sign On
+                    type: boolean
+                    x-nullable: false
+                  plan_change:
+                    description: |
+                      Represents whether or not this product supports changing
+                      the plan of a resource.
+                    type: boolean
+                    x-nullable: false
+                  region:
+                    description: |
+                      Describes how the region for a resource is specified, if
+                      unspecified, then regions have no impact on this
+                      resource.
+                    type: string
+                    enum:
+                    - user-specified
+                    - unspecified
+                additionalProperties: false
+                required:
+                - sso
+            additionalProperties: false
+            required:
+            - base_url
+            - version
+            - features
+            - sso_url
+        additionalProperties: false
+        required:
+        - provider_id
+        - label
+        - name
+        - state
+        - logo_url
+        - tagline
+        - value_props
+        - images
+        - support_email
+        - terms_url
+        - documentation_url
+        - feature_types
+        - billing
+        - integration
+    additionalProperties: false
+    required:
+    - id
+    - version
+    - type
+    - body
+  Plan:
+    type: object
+    properties:
+      id:
+        $ref: '#/definitions/ID'
+      version:
+        type: integer
+        enum:
+        - 1
+      type:
+        type: string
+        enum:
+        - plan
+      body:
+        type: object
+        properties:
+          provider_id:
+            $ref: '#/definitions/ID'
+          product_id:
+            $ref: '#/definitions/ID'
+          name:
+            $ref: '#/definitions/Name'
+          label:
+            $ref: '#/definitions/Label'
+          state:
+            type: string
+            enum:
+            - hidden
+            - available
+            - grandfathered
+          regions:
+            type: array
+            description: Array of Region IDs
+            items:
+              $ref: '#/definitions/ID'
+          features:
+            type: array
+            description: Array of Feature Values
+            items:
+              $ref: '#/definitions/FeatureValue'
+          trial_days:
+            type: integer
+            minimum: 0
+            description: |
+              The number of days a user gets as a free trial when subscribing to
+              this plan. Trials are valid only once per product; changing plans
+              or adding an additional subscription will not start a new trial.
+          cost:
+            type: integer
+            minimum: 0
+            description: Dollar value in cents
+        additionalProperties: false
+        required:
+        - provider_id
+        - product_id
+        - name
+        - label
+        - state
+        - regions
+        - features
+        - cost
+    additionalProperties: false
+    required:
+    - id
+    - version
+    - type
+    - body
+  Error:
+    type: object
+    description: Unexpected error
+    properties:
+      type:
+        type: string
+        description: The error type
+      message:
+        type: array
+        description: Explanation of the errors
+        items:
+          type: string
+    additionalProperties: false
+    required:
+    - type
+    - message
+    x-go-type:
+      type: Error
+      import:
+        package: github.com/manifoldco/go-manifold
+        alias: manifold

--- a/specs/connector.yaml
+++ b/specs/connector.yaml
@@ -1,0 +1,543 @@
+swagger: "2.0"
+info:
+  title: Connector API
+  description: |
+    # Introduction
+    The Connector API allows Providers to query Manifold for data related to
+    provisioned resources and users of those resources.
+
+    The API is available at `https://api.connector.manifold.co`.
+
+    # Authentication
+    An [OAuth 2.0](https://tools.ietf.org/html/rfc6749) [Bearer
+    Token](https://tools.ietf.org/html/rfc6750) is used to authenticate with
+    the Connector API. An access token is granted to a provider either by the
+    provider themselves or by a user as part of the Single Sign-On flow.
+
+    Requests that require authentication will return `401 Unauthorized`. If the
+    requester has insufficient access a `404 Not Found` may be returned instead
+    of a `401 Unauthorized`. This is to prevent the accidental leakage of
+    private data.
+
+    Access Tokens are valid for 24 hours.
+
+    OAuth Credentials are given to providers by Manifold and are scoped to a
+    specific product in the Manifold Catalog. All granted access tokens are
+    scoped to the product's credentials.
+
+    To acquire a set of OAuth Credentials please contact [Manifold
+    Support](mailto:support@manifold.co).
+  version: 1.0.0
+host: api.connector.manifold.co
+schemes:
+- https
+produces:
+- application/json
+consumes:
+- application/json
+securityDefinitions:
+  oauth:
+    type: oauth2
+    description: Authentication mechanism for external provider services.
+    flow: accessCode
+    authorizationUrl: https://api.connector.manifold.co/v1/oauth/authorize
+    tokenUrl: https://api.connector.manifold.co/v1/oauth/tokens
+parameters:
+  resource_id:
+    name: id
+    in: path
+    description: |
+      ID of a Resource object, stored as a base32 encoded 18 byte identifier.
+    required: true
+    type: string
+    pattern: ^[0-9abcdefghjkmnpqrtuvwxyz]{29}$
+    format: base32ID
+  callback_id:
+    name: id
+    in: path
+    description: |
+      ID of a Callback, stored as a base32 encoded 18 byte identifier.
+    required: true
+    type: string
+    pattern: ^[0-9abcdefghjkmnpqrtuvwxyz]{29}$
+    format: base32ID
+responses:
+  BadRequest:
+    description: Request denied due to invalid request body, path, or headers.
+    schema:
+      $ref: '#/definitions/Error'
+    examples:
+      application/json:
+        type: bad_request
+        message:
+        - Invalid Resource ID Provided
+  Unauthorized:
+    description: Request denied as the provided credentials are no longer valid.
+    schema:
+      $ref: '#/definitions/Error'
+    examples:
+      application/json:
+        type: invalid_grant
+        message:
+        - Provided authorization_code is invalid or does not exist.
+  NotFound:
+    description: Request denied as the requested resource does not exist.
+    schema:
+      $ref: '#/definitions/Error'
+    examples:
+      application/json:
+        type: not_found
+        message:
+        - Resource not found
+  Internal:
+    description: Request failed due to an internal server error.
+    schema:
+      $ref: '#/definitions/Error'
+    examples:
+      application/json:
+        type: internal
+        message:
+        - Internal Server Error
+  TokenBadRequest:
+    description: Request denied due to invalid request body, path, or headers.
+    schema:
+      $ref: '#/definitions/OAuthError'
+    examples:
+      application/json:
+        error: invalid_grant
+        error_description: Provided authorization_code is invalid or does not exist.
+  TokenUnauthorized:
+    description: Request denied as the provided credentials are no longer valid.
+    schema:
+      $ref: '#/definitions/OAuthError'
+    examples:
+      application/json:
+        error: invalid_client
+        error_description: Provided client_id and client_secret do not match
+security:
+- oauth: []
+basePath: /v1
+paths:
+  /sso:
+    x-manifold-audience: browser
+    post:
+      summary: Create Authorization Code
+      description: |
+        Endpoint for creating an authorization code used by the user to issue
+        an SSO request against a providers API from the Dashboard.
+      security:
+      - jwtRequired: []
+      tags:
+      - OAuth
+      parameters:
+      - name: body
+        in: body
+        description: Authorization Code Request Body
+        required: true
+        schema:
+          $ref: '#/definitions/AuthCodeRequest'
+      responses:
+        201:
+          description: An authorization code has been created.
+          schema:
+            $ref: '#/definitions/AuthorizationCode'
+        400:
+          $ref: '#/responses/BadRequest'
+        401:
+          $ref: '#/responses/Unauthorized'
+        500:
+          $ref: '#/responses/Internal'
+definitions:
+  ID:
+    type: string
+    description: A base32 encoded 18 byte identifier.
+    pattern: ^[0-9abcdefghjkmnpqrtuvwxyz]{29}$
+    format: base32ID
+    x-go-type:
+      type: ID
+      import:
+        package: github.com/manifoldco/go-manifold
+        alias: manifold
+  Label:
+    type: string
+    description: A machine readable unique label, which is url safe.
+    pattern: ^[a-z0-9][a-z0-9\-\_]{1,128}$
+    x-go-type:
+      type: Label
+      import:
+        package: github.com/manifoldco/go-manifold
+        alias: manifold
+  Name:
+    type: string
+    description: A name of an entity which is displayed to a human.
+    pattern: ^[a-zA-Z][a-z0-9A-Z \-]{2,128}$
+    x-go-type:
+      type: Name
+      import:
+        package: github.com/manifoldco/go-manifold
+        alias: manifold
+  RegionSlug:
+    type: string
+    description: |
+      Combination of the cloud platform and location to provision this
+      resource within.
+    pattern: ^([a-z0-9][a-z0-9\-_]{1,63})::([a-z0-9][a-z0-9\-_]{1,63})$
+  Code:
+    type: string
+    minLength: 13
+    maxLength: 13
+    description: |
+      An authorization code used by a provider in exchange for a scoped
+      Access Token.
+  Email:
+    type: string
+    format: email
+    description: A valid e-mail address.
+    x-go-type:
+      type: Email
+      import:
+        package: github.com/manifoldco/go-manifold
+        alias: manifold
+  Error:
+    type: object
+    properties:
+      type:
+        type: string
+        enum:
+        - bad_request
+        - unauthorized
+        - not_found
+        - internal
+        - invalid_grant
+        - unsupported_grant_type
+        description: The error type
+      message:
+        type: array
+        description: Explanation of the errors
+        items:
+          type: string
+    x-go-type:
+      type: Error
+      import:
+        package: github.com/manifoldco/go-manifold
+        alias: manifold
+  OAuthError:
+    type: object
+    properties:
+      error:
+        type: string
+        enum:
+        - invalid_request
+        - invalid_client
+        - invalid_grant
+        - unauthorized_client
+        - unsupported_grant_type
+        - invalid_scope
+        - access_denied
+        description: The error type
+      error_description:
+        type: string
+        description: Explanation of the error
+    additionalProperties: false
+    required:
+    - error
+    x-go-type:
+      type: OAuthError
+      import:
+        package: github.com/manifoldco/go-connector
+        alias: connector
+  AuthCodeRequest:
+    description: HTTP Request Body of an Auth Code
+    type: object
+    properties:
+      body:
+        type: object
+        properties:
+          resource_id:
+            $ref: '#/definitions/ID'
+        additionalProperties: false
+        required:
+        - resource_id
+    additionalProperties: false
+    required:
+    - body
+  AuthorizationCode:
+    type: object
+    properties:
+      id:
+        $ref: '#/definitions/ID'
+      version:
+        type: string
+        enum:
+        - "1"
+      type:
+        type: string
+        enum:
+        - authorization_code
+      body:
+        type: object
+        properties:
+          user_id:
+            $ref: '#/definitions/ID'
+          resource_id:
+            $ref: '#/definitions/ID'
+          created_at:
+            type: string
+            format: datetime
+          expires_at:
+            type: string
+            format: datetime
+          code:
+            $ref: '#/definitions/Code'
+          redirect_uri:
+            type: string
+            format: url
+        additionalProperties: false
+        required:
+        - user_id
+        - resource_id
+        - created_at
+        - expires_at
+        - code
+        - redirect_uri
+    additionalProperties: false
+    required:
+    - id
+    - version
+    - type
+    - body
+    x-go-type:
+      type: OAuthAuthorizationCode
+      import:
+        package: github.com/manifoldco/marketplace/connector/primitives
+  OAuthClientID:
+    description: |
+      Client ID portion of the OAuth Credentials used for accessing the
+      Manifold Connector API.
+    type: string
+    pattern: ^[0-9abcdefghjkmnpqrtuvwxyz]{29}$
+    format: base32ID
+    x-go-type:
+      type: ID
+      import:
+        package: github.com/manifoldco/go-manifold
+        alias: manifold
+  OAuthClientSecret:
+    type: string
+    minLength: 43
+    maxLength: 43
+    pattern: ^[a-zA-Z0-9_-]{43}$
+    description: |
+      Client Secret portion of the OAuth Credentials used for accessing the
+      Manifold Connector API. A client secret is a 32byte base64 encoded value.
+
+      This value must be kept a secret.
+  AccessTokenRequest:
+    description: HTTP Request Body of an Access Token
+    discriminator: grant_type
+    type: object
+    properties:
+      grant_type:
+        type: string
+        enum:
+        - authorization_code
+        - client_credentials
+      client_id:
+        $ref: '#/definitions/OAuthClientID'
+      client_secret:
+        $ref: '#/definitions/OAuthClientSecret'
+    additionalProperties: false
+    required:
+    - grant_type
+  client_credentials:
+    type: object
+    allOf:
+    - $ref: '#/definitions/AccessTokenRequest'
+  authorization_code:
+    type: object
+    allOf:
+    - $ref: '#/definitions/AccessTokenRequest'
+    - type: object
+      properties:
+        code:
+          $ref: '#/definitions/Code'
+      additionalProperties: false
+      required:
+      - code
+  AccessToken:
+    description: |
+      A granted access token used for performing requests on behalf o a user
+      or provider against the Manifold Connector API.
+    type: object
+    properties:
+      access_token:
+        type: string
+        maxLength: 295
+      token_type:
+        type: string
+        enum:
+        - bearer
+      expires_in:
+        type: integer
+    additionalProperties: false
+    required:
+    - access_token
+    - token_type
+    - expires_in
+  Identity:
+    description: The underlying actor represented by the current Access Token.
+    discriminator: type
+    type: object
+    properties:
+      type:
+        type: string
+        enum:
+        - user
+        - product
+    additionalProperties: false
+    required:
+    - type
+  product:
+    allOf:
+    - $ref: '#/definitions/Identity'
+    - type: object
+      properties:
+        target:
+          type: object
+          properties:
+            name:
+              $ref: '#/definitions/Name'
+            label:
+              $ref: '#/definitions/Label'
+          additionalProperties: false
+          required:
+          - name
+          - label
+      required:
+      - target
+  user:
+    allOf:
+    - $ref: '#/definitions/Identity'
+    - type: object
+      properties:
+        target:
+          type: object
+          properties:
+            name:
+              $ref: '#/definitions/Name'
+            email:
+              $ref: '#/definitions/Email'
+          additionalProperties: false
+          required:
+          - name
+          - email
+      required:
+      - target
+  Profile:
+    description: |
+      A view of a Manifold User.
+
+      Do not store any of this data, instead query Manifold for the most up to
+      date information.
+    type: object
+    properties:
+      name:
+        $ref: '#/definitions/Name'
+      email:
+        $ref: '#/definitions/Email'
+    additionalProperties: false
+    required:
+    - name
+    - email
+  Resource:
+    description: |
+      A view of a Resource provisioned through Manifold.
+
+      Do not store any of this data, instead query Manifold for the most up to
+      date information.
+    type: object
+    properties:
+      id:
+        $ref: '#/definitions/ID'
+      product:
+        $ref: '#/definitions/Label'
+      plan:
+        $ref: '#/definitions/Label'
+      region:
+        $ref: '#/definitions/RegionSlug'
+      name:
+        $ref: '#/definitions/Name'
+      created_at:
+        type: string
+        format: datetime
+      updated_at:
+        type: string
+        format: datetime
+  CallbackResponse:
+    type: object
+    description: |
+      A callback sent from a provider to complete an asynchronous request.
+
+      Credentials can only be specified *if* the callback corresponds with a
+      credential provisioning request.
+    properties:
+      state:
+        type: string
+        enum:
+        - done
+        - error
+      message:
+        type: string
+        minLength: 3
+        maxLength: 256
+      credentials:
+        type: object
+        additionalProperties:
+          type: string
+    additionalProperties: false
+    required:
+    - state
+    - message
+  OAuthCredentialCreateRequest:
+    type: object
+    properties:
+      product_id:
+        $ref: '#/definitions/ID'
+      description:
+        type: string
+        minLength: 3
+        maxLength: 256
+        description: |
+          A human readable description of this credential pair.
+    required:
+    - product_id
+    - description
+    additionalProperties: false
+  OAuthCredentialGetResponse:
+    allOf:
+    - type: object
+      properties:
+        id:
+          $ref: '#/definitions/OAuthClientID'
+        created_at:
+          type: string
+          format: datetime
+        updated_at:
+          type: string
+          format: datetime
+      required:
+      - id
+      - created_at
+      - updated_at
+      additionalProperties: false
+    - $ref: '#/definitions/OAuthCredentialCreateRequest'
+  OAuthCredentialCreateResponse:
+    allOf:
+    - type: object
+      properties:
+        secret:
+          $ref: '#/definitions/OAuthClientSecret'
+      required:
+      - secret
+      additionalProperties: false
+    - $ref: '#/definitions/OAuthCredentialGetResponse'

--- a/specs/identity.yaml
+++ b/specs/identity.yaml
@@ -1,0 +1,728 @@
+swagger: "2.0"
+info:
+  title: Identity API
+  description: Identity and authentication
+  version: 1.0.0
+host: api.identity.manifold.co
+schemes:
+- https
+produces:
+- application/json
+consumes:
+- application/json
+basePath: /v1
+securityDefinitions:
+  jwtRequired:
+    type: apiKey
+    name: Authorization
+    in: header
+  tokenSignatureRequired:
+    type: apiKey
+    name: Authorization
+    in: header
+security:
+- jwtRequired: []
+paths:
+  /tokens/auth:
+    post:
+      summary: Create a new auth token
+      parameters:
+      - name: body
+        in: body
+        description: |
+          Auth token create request
+        required: true
+        schema:
+          $ref: '#/definitions/AuthTokenRequest'
+      - name: authorization
+        in: header
+        description: Token used to authenticate a user against a specific service
+        required: true
+        type: string
+      tags:
+      - Authentication
+      responses:
+        201:
+          description: An authentication token.
+          schema:
+            $ref: '#/definitions/AuthToken'
+        400:
+          description: Invalid token request supplied
+          schema:
+            $ref: '#/definitions/Error'
+        401:
+          description: Expired token supplied
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Request failed due to an internal server error.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /tokens/login:
+    post:
+      summary: Create a new auth or login token
+      security: []
+      parameters:
+      - name: body
+        in: body
+        description: |
+          Login token create request
+        required: true
+        schema:
+          $ref: '#/definitions/LoginTokenRequest'
+      tags:
+      - Authentication
+      responses:
+        201:
+          description: A login token.
+          schema:
+            $ref: '#/definitions/LoginTokenResponse'
+        400:
+          description: Invalid token request supplied
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Request failed due to an internal server error.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /tokens/{token}:
+    delete:
+      summary: Revoke an auth token for log out
+      parameters:
+      - name: token
+        in: path
+        required: true
+        type: string
+        maxLength: 295
+      tags:
+      - Authentication
+      responses:
+        204:
+          description: Empty response
+        401:
+          description: Unknown token, or token not owned the the requester
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Request failed due to an internal server error.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /self:
+    get:
+      summary: Retrieve the underlying user represented by a Token
+      parameters: []
+      tags:
+      - User
+      responses:
+        200:
+          description: A user object.
+          schema:
+            $ref: '#/definitions/User'
+        401:
+          description: Unknown token, or token not owned the the requester
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Request failed due to an internal server error.
+          schema:
+            $ref: '#/definitions/Error'
+  /users:
+    post:
+      summary: Create a new user
+      security: []
+      tags:
+      - User
+      parameters:
+      - name: body
+        in: body
+        description: |
+          User create request
+        required: true
+        schema:
+          $ref: '#/definitions/CreateUser'
+      responses:
+        201:
+          description: Complete user object
+          schema:
+            $ref: '#/definitions/User'
+        400:
+          description: Validation failed for request
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Request failed due to an internal server error.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /users/forgot-password:
+    post:
+      x-manifold-audience: browser
+      security: []
+      summary: Reset password with an emailed forgot password token
+      tags:
+      - User
+      parameters:
+      - name: body
+        in: body
+        description: |
+          Forgot password payload
+        required: true
+        schema:
+          $ref: '#/definitions/ForgotPassword'
+      responses:
+        204:
+          description: Forgot password complete
+        401:
+          description: Validation failed for request
+          schema:
+            $ref: '#/definitions/Error'
+        400:
+          description: Validation failed for request
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Request failed due to an internal server error.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /users/forgot-password/token:
+    post:
+      x-manifold-audience: browser
+      security: []
+      summary: User has forgotten password, send a reset token
+      tags:
+      - User
+      parameters:
+      - name: body
+        in: body
+        description: |
+          Request to be issued a forgot password token
+        required: true
+        schema:
+          $ref: '#/definitions/ForgotPasswordCreate'
+      responses:
+        204:
+          description: Forgot password has either been sent, or ignored for unknown
+            user
+        401:
+          description: Validation failed for request
+          schema:
+            $ref: '#/definitions/Error'
+        400:
+          description: Validation failed for request
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Request failed due to an internal server error.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /users/verify:
+    post:
+      summary: Verify email address
+      tags:
+      - User
+      parameters:
+      - name: body
+        in: body
+        description: |
+          Email verify request
+        required: true
+        schema:
+          $ref: '#/definitions/VerifyEmail'
+      responses:
+        204:
+          description: Verification complete
+        401:
+          description: Validation failed for request
+          schema:
+            $ref: '#/definitions/Error'
+        400:
+          description: Validation failed for request
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Request failed due to an internal server error.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /users/{id}:
+    patch:
+      summary: Update user profile
+      security:
+      - tokenSignatureRequired: []
+      tags:
+      - User
+      parameters:
+      - name: id
+        in: path
+        description: |
+          ID of the user to update, stored as a base32 encoded 18 byte
+          identifier.
+        required: true
+        type: string
+        pattern: ^[0-9abcdefghjkmnpqrtuvwxyz]{29}$
+        format: base32ID
+      - name: body
+        in: body
+        description: |
+          User update request
+        required: true
+        schema:
+          $ref: '#/definitions/UpdateUser'
+      responses:
+        200:
+          description: Complete user object
+          schema:
+            $ref: '#/definitions/User'
+        400:
+          description: Validation failed for request
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Request failed due to an internal server error.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /teams:
+    post:
+      summary: Create a new team
+      tags:
+      - Team
+      parameters:
+      - name: body
+        in: body
+        description: |
+          Team create request.
+        required: true
+        schema:
+          $ref: '#/definitions/CreateTeam'
+      responses:
+        201:
+          description: Complete team object
+          schema:
+            $ref: '#/definitions/Team'
+        400:
+          description: Validation failed for request.
+          schema:
+            $ref: '#/definitions/Error'
+        401:
+          description: Authentication failed for the request.
+          schema:
+            $ref: '#/definitions/Error'
+        403:
+          description: The user has already created (reserved) an team.
+          schema:
+            $ref: '#/definitions/Error'
+        409:
+          description: An team with this label already exists.
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Request failed due to an internal server error.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+definitions:
+  ID:
+    type: string
+    description: A base32 encoded 18 byte identifier.
+    pattern: ^[0-9abcdefghjkmnpqrtuvwxyz]{29}$
+    format: base32ID
+    x-go-type:
+      type: ID
+      import:
+        package: github.com/manifoldco/go-manifold
+        alias: manifold
+  Label:
+    type: string
+    description: A machine readable unique label, which is url safe.
+    pattern: ^[a-z0-9][a-z0-9\-\_]{1,128}$
+    x-go-type:
+      type: Label
+      import:
+        package: github.com/manifoldco/go-manifold
+        alias: manifold
+  Name:
+    type: string
+    description: A name of an entity which is displayed to a human.
+    pattern: ^[a-zA-Z][a-z0-9A-Z \-]{2,128}$
+    x-go-type:
+      type: Name
+      import:
+        package: github.com/manifoldco/go-manifold
+        alias: manifold
+  Empty:
+    type: object
+    additionalProperties: false
+  Error:
+    type: object
+    properties:
+      type:
+        description: The error type
+        type: string
+        enum:
+        - bad_request
+        - not_found
+        - unauthorized
+        - conflict
+        - internal
+      message:
+        type: array
+        description: Explanation of the errors
+        items:
+          type: string
+    x-go-type:
+      type: Error
+      import:
+        package: github.com/manifoldco/go-manifold
+        alias: manifold
+  User:
+    type: object
+    properties:
+      id:
+        $ref: '#/definitions/ID'
+      version:
+        type: integer
+        enum:
+        - 1
+      type:
+        type: string
+        enum:
+        - user
+      body:
+        type: object
+        properties:
+          name:
+            $ref: '#/definitions/UserDisplayName'
+          email:
+            $ref: '#/definitions/Email'
+          public_key:
+            $ref: '#/definitions/LoginPublicKey'
+          verification_code:
+            type: string
+            pattern: ^[0-9abcdefghjkmnpqrtuvwxyz]{16}$
+            maxLength: 16
+          state:
+            type: string
+            enum:
+            - unverified
+            - verified
+        additionalProperties: false
+        required:
+        - name
+        - email
+        - public_key
+        - state
+    additionalProperties: false
+    required:
+    - id
+    - type
+    - version
+    - body
+  CreateUser:
+    type: object
+    properties:
+      body:
+        type: object
+        properties:
+          name:
+            $ref: '#/definitions/UserDisplayName'
+          email:
+            $ref: '#/definitions/Email'
+          public_key:
+            $ref: '#/definitions/LoginPublicKey'
+        additionalProperties: false
+        required:
+        - name
+        - email
+        - public_key
+    additionalProperties: false
+    required:
+    - body
+  CreateTeam:
+    type: object
+    properties:
+      body:
+        type: object
+        properties:
+          name:
+            $ref: '#/definitions/Name'
+          label:
+            $ref: '#/definitions/Label'
+        additionalProperties: false
+        required:
+        - name
+        - label
+    additionalProperties: false
+    required:
+    - body
+  Team:
+    type: object
+    properties:
+      id:
+        $ref: '#/definitions/ID'
+      type:
+        type: string
+        enum:
+        - team
+      version:
+        type: integer
+        enum:
+        - 1
+      body:
+        type: object
+        properties:
+          name:
+            $ref: '#/definitions/Name'
+          label:
+            $ref: '#/definitions/Label'
+        additionalProperties: false
+        required:
+        - name
+        - label
+    additionalProperties: false
+    required:
+    - id
+    - type
+    - version
+    - body
+    x-go-type:
+      type: Team
+      import:
+        package: github.com/manifoldco/marketplace/identity/primitives
+  UpdateUser:
+    type: object
+    properties:
+      body:
+        type: object
+        properties:
+          name:
+            $ref: '#/definitions/UserDisplayName'
+          email:
+            $ref: '#/definitions/Email'
+          public_key:
+            $ref: '#/definitions/LoginPublicKey'
+          auth_token_sig:
+            type: string
+            pattern: ^[a-zA-Z0-9_-]*$
+            minLength: 86
+            maxLength: 86
+        additionalProperties: false
+    additionalProperties: false
+  ForgotPassword:
+    type: object
+    properties:
+      email:
+        $ref: '#/definitions/Email'
+      token:
+        type: string
+        minLength: 43
+        maxLength: 43
+        pattern: ^[a-zA-Z0-9_-]{43}$
+      public_key:
+        $ref: '#/definitions/LoginPublicKey'
+    additionalProperties: false
+    required:
+    - email
+    - token
+    - public_key
+  ForgotPasswordCreate:
+    type: object
+    properties:
+      email:
+        $ref: '#/definitions/Email'
+    additionalProperties: false
+    required:
+    - email
+  VerifyEmail:
+    type: object
+    properties:
+      body:
+        type: object
+        properties:
+          verification_code:
+            type: string
+            pattern: ^[0-9abcdefghjkmnpqrtuvwxyz]{16}$
+            maxLength: 16
+        additionalProperties: false
+        required:
+        - verification_code
+  UserDisplayName:
+    type: string
+    pattern: ^[a-zA-Z\s\,\.\'\-\pL]+$
+    minLength: 3
+    maxLength: 64
+  Email:
+    type: string
+    format: email
+    x-go-type:
+      type: Email
+      import:
+        package: github.com/manifoldco/go-manifold
+        alias: manifold
+  LoginPublicKey:
+    type: object
+    properties:
+      salt:
+        type: string
+        pattern: ^[a-zA-Z0-9_-]*$
+        minLength: 22
+        maxLength: 22
+      value:
+        type: string
+        pattern: ^[a-zA-Z0-9_-]*$
+        minLength: 43
+        maxLength: 43
+      alg:
+        type: string
+        enum:
+        - eddsa
+    additionalProperties: false
+    required:
+    - salt
+    - value
+    - alg
+  AuthTokenRequest:
+    type: object
+    properties:
+      type:
+        type: string
+        enum:
+        - auth
+      login_token_sig:
+        type: string
+        pattern: ^[a-zA-Z0-9_-]*$
+        minLength: 86
+        maxLength: 86
+    additionalProperties: false
+    required:
+    - type
+    - login_token_sig
+  AuthToken:
+    type: object
+    properties:
+      id:
+        $ref: '#/definitions/ID'
+      version:
+        type: integer
+        enum:
+        - 1
+      type:
+        type: string
+        enum:
+        - auth_token
+      body:
+        type: object
+        properties:
+          token:
+            type: string
+            maxLength: 295
+          user_id:
+            $ref: '#/definitions/ID'
+          mechanism:
+            type: string
+            enum:
+            - eddsa
+            x-nullable: false
+        additionalProperties: false
+        required:
+        - token
+        - user_id
+        - type
+        - mechanism
+    additionalProperties: false
+    required:
+    - id
+    - version
+    - type
+    - body
+  LoginTokenRequest:
+    type: object
+    properties:
+      email:
+        type: string
+        format: email
+    required:
+    - email
+  LoginTokenResponse:
+    type: object
+    properties:
+      token:
+        type: string
+      salt:
+        type: string
+        pattern: ^[a-zA-Z0-9_-]*$
+        minLength: 22
+        maxLength: 22
+    required:
+    - token
+    - salt
+  LoginToken:
+    type: object
+    properties:
+      id:
+        $ref: '#/definitions/ID'
+      version:
+        type: integer
+        enum:
+        - 1
+      type:
+        type: string
+        enum:
+        - login_token
+      body:
+        type: object
+        properties:
+          token:
+            type: string
+            maxLength: 295
+          user_id:
+            $ref: '#/definitions/ID'
+          mechanism:
+            type: string
+            enum:
+            - eddsa
+            x-nullable: false
+        additionalProperties: false
+        required:
+        - token
+        - user_id
+        - type
+        - mechanism
+    additionalProperties: false
+    required:
+    - id
+    - version
+    - type
+    - body

--- a/specs/marketplace.yaml
+++ b/specs/marketplace.yaml
@@ -1,0 +1,438 @@
+swagger: "2.0"
+info:
+  title: Marketplace API
+  description: |
+    Request and monitor resource provisioning, deprovisioning, and resizing
+    operations
+  version: 1.0.0
+host: api.marketplace.manifold.co
+schemes:
+- https
+produces:
+- application/json
+consumes:
+- application/json
+securityDefinitions:
+  jwtRequired:
+    type: apiKey
+    name: Authorization
+    in: header
+security:
+- jwtRequired: []
+basePath: /v1
+paths:
+  /resources/:
+    get:
+      summary: List all provisioned resources
+      tags:
+      - Resource
+      parameters:
+      - name: product_id
+        in: query
+        description: |
+          ID of the Product to filter Resources by, stored as a
+          base32encoded 18 byte identifier.
+        type: string
+        pattern: ^[0-9abcdefghjkmnpqrtuvwxyz]{29}$
+        format: base32ID
+        required: false
+      responses:
+        200:
+          description: List of provisioned resources
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Resource'
+        500:
+          description: Server Error
+          schema:
+            $ref: '#/definitions/Error'
+        401:
+          description: Invalid Auth Token
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected Error
+  /resources/{id}:
+    get:
+      summary: Retrieve a resource
+      parameters:
+      - name: id
+        in: path
+        description: |
+          ID of the Resource to lookup, stored as a base32 encoded 18 byte
+          identifier.
+        required: true
+        type: string
+        pattern: ^[0-9abcdefghjkmnpqrtuvwxyz]{29}$
+        format: base32ID
+      tags:
+      - Resource
+      responses:
+        200:
+          description: A resource.
+          schema:
+            $ref: '#/definitions/Resource'
+        404:
+          description: No resource with the given ID exists.
+          schema:
+            $ref: '#/definitions/Error'
+        401:
+          description: Invalid Auth Token
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Server Error
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected Error
+          schema:
+            $ref: '#/definitions/Error'
+    patch:
+      summary: |
+        Update a resource name or other property that doesn't require
+        communication with the provider.
+      parameters:
+      - name: id
+        in: path
+        description: |
+          ID of the Resource to lookup, stored as a base32 encoded 18 byte
+          identifier.
+        required: true
+        type: string
+        pattern: ^[0-9abcdefghjkmnpqrtuvwxyz]{29}$
+        format: base32ID
+      - name: body
+        in: body
+        description: Resource update request
+        required: true
+        schema:
+          $ref: '#/definitions/PublicUpdateResource'
+      tags:
+      - Resource
+      responses:
+        200:
+          description: An updated resource object.
+          schema:
+            $ref: '#/definitions/Resource'
+        401:
+          description: Invalid Auth Token
+          schema:
+            $ref: '#/definitions/Error'
+        400:
+          description: Invalid Request
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Server Error
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected Error
+          schema:
+            $ref: '#/definitions/Error'
+  /credentials:
+    get:
+      summary: List credentials
+      parameters:
+      - name: resource_id
+        in: query
+        description: |
+          ID of the Resource to filter Credentials by, stored as a
+          base32encoded 18 byte identifier.
+        type: string
+        pattern: ^[0-9abcdefghjkmnpqrtuvwxyz]{29}$
+        format: base32ID
+        required: true
+      tags:
+      - Credential
+      responses:
+        200:
+          description: List of Credentials
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Credential'
+        401:
+          description: Invalid Auth Token
+          schema:
+            $ref: '#/definitions/Error'
+        400:
+          description: Invalid Request
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Server Error
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected Error
+          schema:
+            $ref: '#/definitions/Error'
+definitions:
+  ID:
+    type: string
+    description: A base32 encoded 18 byte identifier.
+    pattern: ^[0-9abcdefghjkmnpqrtuvwxyz]{29}$
+    format: base32ID
+    x-go-type:
+      type: ID
+      import:
+        package: github.com/manifoldco/go-manifold
+        alias: manifold
+  Label:
+    type: string
+    description: A machine readable unique label, which is url safe.
+    pattern: ^[a-z0-9][a-z0-9\-\_]{1,128}$
+    x-go-type:
+      type: Label
+      import:
+        package: github.com/manifoldco/go-manifold
+        alias: manifold
+  Name:
+    type: string
+    description: A name of an entity which is displayed to a human.
+    pattern: ^[a-zA-Z][a-z0-9A-Z \-]{2,128}$
+    x-go-type:
+      type: Name
+      import:
+        package: github.com/manifoldco/go-manifold
+        alias: manifold
+  Error:
+    type: object
+    properties:
+      type:
+        type: string
+        description: The error type
+        enum:
+        - bad_request
+        - not_found
+        - unauthorized
+        - conflict
+        - internal
+      message:
+        type: array
+        description: Explanation of the errors
+        items:
+          type: string
+    x-go-type:
+      type: Error
+      import:
+        package: github.com/manifoldco/go-manifold
+        alias: manifold
+  CreateResource:
+    type: object
+    properties:
+      id:
+        $ref: '#/definitions/ID'
+      type:
+        type: string
+        enum:
+        - resource
+      version:
+        type: integer
+        enum:
+        - 1
+      body:
+        type: object
+        properties:
+          name:
+            $ref: '#/definitions/Name'
+          label:
+            $ref: '#/definitions/Label'
+          app_name:
+            $ref: '#/definitions/Name'
+          user_id:
+            $ref: '#/definitions/ID'
+          product_id:
+            $ref: '#/definitions/ID'
+          plan_id:
+            $ref: '#/definitions/ID'
+          region_id:
+            $ref: '#/definitions/ID'
+          created_at:
+            type: string
+            format: datetime
+          updated_at:
+            type: string
+            format: datetime
+        additionalProperties: false
+        required:
+        - name
+        - label
+        - product_id
+        - plan_id
+        - region_id
+    additionalProperties: false
+    required:
+    - id
+    - type
+    - version
+    - body
+  Resource:
+    type: object
+    properties:
+      id:
+        $ref: '#/definitions/ID'
+      type:
+        type: string
+        enum:
+        - resource
+      version:
+        type: integer
+        enum:
+        - 1
+      body:
+        type: object
+        properties:
+          name:
+            $ref: '#/definitions/Name'
+          label:
+            $ref: '#/definitions/Label'
+          app_name:
+            $ref: '#/definitions/Name'
+          user_id:
+            $ref: '#/definitions/ID'
+          product_id:
+            $ref: '#/definitions/ID'
+          plan_id:
+            $ref: '#/definitions/ID'
+          region_id:
+            $ref: '#/definitions/ID'
+          created_at:
+            type: string
+            format: datetime
+          updated_at:
+            type: string
+            format: datetime
+        additionalProperties: false
+        required:
+        - name
+        - label
+        - user_id
+        - product_id
+        - plan_id
+        - region_id
+        - created_at
+        - updated_at
+    additionalProperties: false
+    required:
+    - id
+    - type
+    - version
+    - body
+  PublicUpdateResource:
+    type: object
+    description: Shape of request used to update a resource through a public api
+    properties:
+      body:
+        type: object
+        properties:
+          name:
+            $ref: '#/definitions/Name'
+          label:
+            $ref: '#/definitions/Label'
+          app_name:
+            x-nullable: true
+            type: string
+            pattern: ^[a-zA-Z][a-z0-9A-Z \-]{2,128}$
+        additionalProperties: false
+    additionalProperties: false
+    required:
+    - body
+  InternalUpdateResource:
+    type: object
+    description: Shape of request used to update a resource through an internal api
+    properties:
+      body:
+        type: object
+        properties:
+          plan_id:
+            $ref: '#/definitions/ID'
+        additionalProperties: false
+        required:
+        - plan_id
+    additionalProperties: false
+    required:
+    - body
+  CreateCredential:
+    type: object
+    properties:
+      id:
+        $ref: '#/definitions/ID'
+      type:
+        type: string
+        enum:
+        - credential
+      version:
+        type: integer
+        enum:
+        - 1
+      body:
+        type: object
+        properties:
+          user_id:
+            $ref: '#/definitions/ID'
+          resource_id:
+            $ref: '#/definitions/ID'
+          values:
+            type: object
+            description: |
+              Map of configuration variable names to values, names
+              must IEEE 1003.1 - 2001 Standard (checked in code).
+        additionalProperties: false
+        required:
+        - user_id
+        - resource_id
+        - values
+    additionalProperties: false
+    required:
+    - id
+    - type
+    - version
+    - body
+  Credential:
+    type: object
+    properties:
+      id:
+        $ref: '#/definitions/ID'
+      type:
+        type: string
+        enum:
+        - credential
+      version:
+        type: integer
+        enum:
+        - 1
+      body:
+        type: object
+        properties:
+          user_id:
+            $ref: '#/definitions/ID'
+          resource_id:
+            $ref: '#/definitions/ID'
+          values:
+            type: object
+            description: |
+              Map of configuration variable names to values, names
+              must IEEE 1003.1 - 2001 Standard (checked in code).
+          created_at:
+            type: string
+            format: datetime
+          updated_at:
+            type: string
+            format: datetime
+        additionalProperties: false
+        required:
+        - user_id
+        - resource_id
+        - values
+        - created_at
+        - updated_at
+    additionalProperties: false
+    required:
+    - id
+    - type
+    - version
+    - body

--- a/specs/provisioning.yaml
+++ b/specs/provisioning.yaml
@@ -1,0 +1,358 @@
+swagger: "2.0"
+info:
+  title: Provisioning API
+  description: |
+    Request and monitor resource provisioning, deprovisioning, and resizing
+    operations
+  version: 1.0.0
+host: api.provisioning.manifold.co
+schemes:
+- https
+produces:
+- application/json
+consumes:
+- application/json
+securityDefinitions:
+  jwtRequired:
+    type: apiKey
+    name: Authorization
+    in: header
+security:
+- jwtRequired: []
+parameters:
+  callback_id:
+    name: id
+    in: path
+    description: |
+      ID of a Callback, stored as a base32 encoded 18 byte identifier.
+    required: true
+    type: string
+    pattern: ^[0-9abcdefghjkmnpqrtuvwxyz]{29}$
+    format: base32ID
+responses:
+  BadRequest:
+    description: Request denied due to invalid request body, path, or headers.
+    schema:
+      $ref: '#/definitions/Error'
+  Unauthorized:
+    description: Request denied as the provided credentials are no longer valid.
+    schema:
+      $ref: '#/definitions/Error'
+  NotFound:
+    description: Request denied as the requested resource does not exist.
+    schema:
+      $ref: '#/definitions/Error'
+  Internal:
+    description: Request failed due to an internal server error.
+    schema:
+      $ref: '#/definitions/Error'
+basePath: /v1
+paths:
+  /operations/:
+    get:
+      summary: Get a list of operations
+      tags:
+      - Operation
+      responses:
+        200:
+          description: A list of operations.
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Operation'
+        401:
+          description: Invalid Auth Token
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Unexpected Error
+          schema:
+            $ref: '#/definitions/Error'
+  /operations/{id}:
+    put:
+      summary: Create Operation
+      description: Create an operation to provision, resize, or deprovision a resource.
+      tags:
+      - Operation
+      parameters:
+      - name: id
+        in: path
+        description: |
+          ID of the Operation, stored as a base32 encoded 18 byte identifier.
+        required: true
+        type: string
+        pattern: ^[0-9abcdefghjkmnpqrtuvwxyz]{29}$
+        format: base32ID
+      - name: body
+        in: body
+        description: Operation creation request
+        required: true
+        schema:
+          $ref: '#/definitions/Operation'
+      responses:
+        202:
+          description: An operation to asynchronously watch the progress of a requested
+            action.
+          schema:
+            $ref: '#/definitions/Operation'
+        400:
+          description: Bad Request Parameters
+          schema:
+            $ref: '#/definitions/Error'
+        401:
+          description: Invalid Auth Token
+          schema:
+            $ref: '#/definitions/Error'
+        400:
+          description: Invalid Request
+          schema:
+            $ref: '#/definitions/Error'
+        404:
+          description: Not Found
+          schema:
+            $ref: '#/definitions/Error'
+        409:
+          description: Another operation is being performed on this resource.
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Unexpected Error
+          schema:
+            $ref: '#/definitions/Error'
+    get:
+      summary: Get an Operation
+      description: Retrieve an operation based on its ID
+      parameters:
+      - name: id
+        in: path
+        description: |
+          ID of the operation to lookup, stored as a base32 encoded 18 byte
+          identifier.
+        required: true
+        type: string
+        pattern: ^[0-9abcdefghjkmnpqrtuvwxyz]{29}$
+        format: base32ID
+      tags:
+      - Operation
+      responses:
+        200:
+          description: An operation.
+          schema:
+            $ref: '#/definitions/Operation'
+        400:
+          description: Bad Request Parameters
+          schema:
+            $ref: '#/definitions/Error'
+        404:
+          description: No operation with the given ID exists.
+          schema:
+            $ref: '#/definitions/Error'
+        401:
+          description: Invalid Auth Token
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+definitions:
+  ID:
+    type: string
+    description: A base32 encoded 18 byte identifier.
+    pattern: ^[0-9abcdefghjkmnpqrtuvwxyz]{29}$
+    format: base32ID
+    x-go-type:
+      type: ID
+      import:
+        package: github.com/manifoldco/go-manifold
+        alias: manifold
+  Callback:
+    type: object
+    description: |
+      Current state of a callback
+    properties:
+      id:
+        $ref: '#/definitions/ID'
+      type:
+        type: string
+        enum:
+        - callback
+      version:
+        type: integer
+        enum:
+        - 1
+      body:
+        type: object
+        properties:
+          operation_id:
+            $ref: '#/definitions/ID'
+          payload:
+            $ref: '#/definitions/CallbackResponse'
+  CallbackResponse:
+    type: object
+    description: |
+      A callback sent from a provider to complete an asynchronous request.
+
+      Credentials can only be specified *if* the callback corresponds with a
+      credential provisioning request.
+    properties:
+      state:
+        type: string
+        enum:
+        - done
+        - error
+      message:
+        type: string
+        minLength: 3
+        maxLength: 256
+      credentials:
+        type: object
+        additionalProperties:
+          type: string
+    additionalProperties: false
+    required:
+    - state
+    - message
+  OperationBody:
+    discriminator: type
+    type: object
+    properties:
+      type:
+        type: string
+        description: Type of operation this object represents
+      resource_id:
+        $ref: '#/definitions/ID'
+      user_id:
+        $ref: '#/definitions/ID'
+      message:
+        type: string
+        description: A message associated with the operation to display to the user.
+    additionalProperties: false
+    required:
+    - type
+    - resource_id
+    - user_id
+    - message
+  provision:
+    type: object
+    allOf:
+    - $ref: '#/definitions/OperationBody'
+    - type: object
+      properties:
+        state:
+          description: State must be specified as creating on a PUT operation
+          type: string
+          enum:
+          - provision
+          - binding
+          - billing
+          - commit
+          - error
+          - done
+        product_id:
+          $ref: '#/definitions/ID'
+        plan_id:
+          $ref: '#/definitions/ID'
+        region_id:
+          $ref: '#/definitions/ID'
+        name:
+          type: string
+        label:
+          type: string
+        app_name:
+          description: Optional app name for resource grouping
+          type: string
+      additionalProperties: false
+      required:
+      - state
+      - product_id
+      - plan_id
+      - region_id
+      - name
+      - label
+  resize:
+    type: object
+    allOf:
+    - $ref: '#/definitions/OperationBody'
+    - type: object
+      properties:
+        state:
+          description: State must be specified as resize on a PUT operation
+          type: string
+          enum:
+          - resize
+          - billing
+          - commit
+          - error
+          - done
+        plan_id:
+          $ref: '#/definitions/ID'
+      additionalProperties: false
+      required:
+      - state
+      - plan_id
+  deprovision:
+    type: object
+    allOf:
+    - $ref: '#/definitions/OperationBody'
+    - type: object
+      properties:
+        state:
+          description: State must be specified as deprovision on a PUT operation.
+          type: string
+          enum:
+          - deprovision
+          - billing
+          - commit
+          - error
+          - done
+      additionalProperties: false
+      required:
+      - state
+  Operation:
+    type: object
+    properties:
+      id:
+        $ref: '#/definitions/ID'
+      type:
+        type: string
+        enum:
+        - operation
+      version:
+        type: integer
+        enum:
+        - 1
+      body:
+        $ref: '#/definitions/OperationBody'
+    additionalProperties: false
+    required:
+    - id
+    - type
+    - version
+    - body
+    x-go-type:
+      type: Operation
+      import:
+        package: github.com/manifoldco/marketplace/provisioning/primitives
+  Error:
+    type: object
+    properties:
+      type:
+        type: string
+        enum:
+        - bad_request
+        - unauthorized
+        - not_found
+        - conflict
+        - internal
+        description: The error type
+      message:
+        type: array
+        description: Explanation of the errors
+        items:
+          type: string
+    x-go-type:
+      type: Error
+      import:
+        package: github.com/manifoldco/go-manifold
+        alias: manifold


### PR DESCRIPTION
Using the public versions of our swagger specifications for our public
apis (which are coped into the specs folder), we are now generating
clients and associated models to work with our services.

We opened manifoldco/engineering#2506 to address properly sourcing these
spec files in future.

Related manifoldco/engineering#2495