### PR TITLE
Unify Standard Errors

### DIFF
--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -1,0 +1,8 @@
+package main
+
+import (
+	"github.com/urfave/cli"
+)
+
+var errAlreadyLoggedIn = cli.NewExitError("You're alredy logged in!", -1)
+var errAlreadyLoggedOut = cli.NewExitError("You're already logged out!", -1)

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/manifoldco/manifold-cli/prompts"
-	"github.com/manifoldco/manifold-cli/session"
+	"github.com/urfave/cli"
 
 	"github.com/manifoldco/manifold-cli/config"
-	"github.com/urfave/cli"
+	"github.com/manifoldco/manifold-cli/prompts"
+	"github.com/manifoldco/manifold-cli/session"
 )
 
 func init() {
@@ -34,7 +34,7 @@ func login(_ *cli.Context) error {
 	}
 
 	if s.Authenticated() {
-		return cli.NewExitError("You're already logged in!", -1)
+		return errAlreadyLoggedIn
 	}
 
 	email, err := prompts.Email("")

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -29,11 +29,11 @@ func logout(_ *cli.Context) error {
 
 	s, err := session.Retrieve(ctx, cfg)
 	if err != nil {
-		return cli.NewExitError("You are already logged out: "+err.Error(), -1)
+		return cli.NewExitError("Could not retrieve session: "+err.Error(), -1)
 	}
 
 	if !s.Authenticated() {
-		return cli.NewExitError("You're already logged out!", -1)
+		return errAlreadyLoggedOut
 	}
 
 	err = session.Destroy(ctx, cfg)


### PR DESCRIPTION
Unify all of the standard cli errors we output into a single file, the
purpose isn't to have all possible errors listed here, just the expected
output errors that we would propagate to the user inside a command.