### PR TITLE
Introduce App Flag (--app, -a)

### DIFF
--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -9,7 +9,6 @@ import (
 var errMustLogin = cli.NewExitError("You must login to perform that command.", -1)
 var errAlreadyLoggedIn = cli.NewExitError("You're alredy logged in!", -1)
 var errAlreadyLoggedOut = cli.NewExitError("You're already logged out!", -1)
-var errTooManyArgs = cli.NewExitError("You've provided too many arguments!", -1)
 var errInvalidAppName = cli.NewExitError("You've provided an invalid app name!", -1)
 
 func newUsageExitError(ctx *cli.Context, err error) error {

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -29,16 +29,14 @@ var formats = []string{"bash", "powershell", "fish", "cmd", "json"}
 func init() {
 
 	formatFlagStr := fmt.Sprintf("Export format of the secrets (%s)", strings.Join(formats, ", "))
-	flags := []cli.Flag{
-		formatFlag(formats[0], formatFlagStr),
-	}
-
 	exportCmd := cli.Command{
-		Name:      "export",
-		Usage:     "Exports all environment variables from all resources at the account level, optionally exports all environment variables within the specified App Group.",
-		ArgsUsage: "[app]",
-		Action:    export,
-		Flags:     flags,
+		Name:   "export",
+		Usage:  "Exports all environment variables from all resource",
+		Action: export,
+		Flags: []cli.Flag{
+			formatFlag(formats[0], formatFlagStr),
+			appFlag(),
+		},
 	}
 
 	cmds = append(cmds, exportCmd)
@@ -46,20 +44,13 @@ func init() {
 
 func export(cliCtx *cli.Context) error {
 	ctx := context.Background()
-	args := cliCtx.Args()
 
-	if len(args) > 1 {
-		return newUsageExitError(cliCtx, errTooManyArgs)
-	}
-
-	appName := ""
-	if len(args) == 1 {
-		name := manifold.Name(args[0])
+	appName := cliCtx.String("app")
+	if appName != "" {
+		name := manifold.Name(appName)
 		if err := name.Validate(nil); err != nil {
 			return newUsageExitError(cliCtx, errInvalidAppName)
 		}
-
-		appName = string(name)
 	}
 
 	format := cliCtx.String("format")

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -9,3 +9,12 @@ import (
 func formatFlag(defaultValue, description string) cli.Flag {
 	return placeholder.New("format, f", "FORMAT", description, defaultValue, "MANIFOLD_FORMAT", false)
 }
+
+func appFlag() cli.Flag {
+	return cli.StringFlag{
+		Name:   "app, a",
+		Usage:  "Filter output to only items related to the specified App.",
+		Value:  "",
+		EnvVar: "MANIFOLD_APP",
+	}
+}


### PR DESCRIPTION
Instead of having the app name be an optional argument, we've made it a
flag as it's a filter of the output from `export` (and soon to be
`run`).