### PR TITLE
Hide team-owned resources from the CLI until proper support is added

### DIFF
--- a/clients/resources.go
+++ b/clients/resources.go
@@ -1,0 +1,50 @@
+package clients
+
+import (
+	"context"
+
+	mClient "github.com/manifoldco/manifold-cli/generated/marketplace/client"
+	"github.com/manifoldco/manifold-cli/generated/marketplace/client/resource"
+	mModels "github.com/manifoldco/manifold-cli/generated/marketplace/models"
+	pClient "github.com/manifoldco/manifold-cli/generated/provisioning/client"
+	"github.com/manifoldco/manifold-cli/generated/provisioning/client/operation"
+	pModels "github.com/manifoldco/manifold-cli/generated/provisioning/models"
+)
+
+// FetchOperations returns the resources for the authenticated user
+func FetchOperations(ctx context.Context, c *pClient.Provisioning) ([]*pModels.Operation, error) {
+	res, err := c.Operation.GetOperations(
+		operation.NewGetOperationsParamsWithContext(ctx), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []*pModels.Operation
+	for _, o := range res.Payload {
+		// TODO: remove this once CLI has first-class Teams support
+		if !o.Body.TeamID().IsEmpty() {
+			continue
+		}
+		results = append(results, o)
+	}
+	return results, nil
+}
+
+// FetchResources returns the resources for the authenticated user
+func FetchResources(ctx context.Context, c *mClient.Marketplace) ([]*mModels.Resource, error) {
+	res, err := c.Resource.GetResources(
+		resource.NewGetResourcesParamsWithContext(ctx), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []*mModels.Resource
+	for _, r := range res.Payload {
+		// TODO: remove this once CLI has first-class Teams support
+		if !r.Body.TeamID.IsEmpty() {
+			continue
+		}
+		results = append(results, r)
+	}
+	return results, nil
+}

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -21,7 +21,6 @@ import (
 	"github.com/manifoldco/manifold-cli/session"
 
 	cModels "github.com/manifoldco/manifold-cli/generated/catalog/models"
-	"github.com/manifoldco/manifold-cli/generated/marketplace/client/resource"
 	mModels "github.com/manifoldco/manifold-cli/generated/marketplace/models"
 	provisioning "github.com/manifoldco/manifold-cli/generated/provisioning/client"
 	"github.com/manifoldco/manifold-cli/generated/provisioning/client/operation"
@@ -143,13 +142,12 @@ func create(cliCtx *cli.Context) error {
 	}
 
 	// Get resources, so we can fetch the list of valid appnames
-	res, err := mClient.Resource.GetResources(
-		resource.NewGetResourcesParamsWithContext(ctx), nil)
+	res, err := clients.FetchResources(ctx, mClient)
 	if err != nil {
 		return cli.NewExitError("Failed to fetch resource list: "+err.Error(), -1)
 	}
 
-	appNames := fetchUniqueAppNames(res.Payload)
+	appNames := fetchUniqueAppNames(res)
 	newA, appName, err := prompts.SelectCreateAppName(appNames, appName, false)
 	if err != nil {
 		return prompts.HandleSelectError(err, "Could not select app.")

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -21,7 +21,6 @@ import (
 
 	mClient "github.com/manifoldco/manifold-cli/generated/marketplace/client"
 	"github.com/manifoldco/manifold-cli/generated/marketplace/client/credential"
-	"github.com/manifoldco/manifold-cli/generated/marketplace/client/resource"
 	"github.com/manifoldco/manifold-cli/generated/marketplace/models"
 )
 
@@ -80,13 +79,12 @@ func export(cliCtx *cli.Context) error {
 		return cli.NewExitError("Could not create marketplace client: "+err.Error(), -1)
 	}
 
-	p := resource.NewGetResourcesParamsWithContext(ctx)
-	r, err := marketplace.Resource.GetResources(p, nil)
+	r, err := clients.FetchResources(ctx, marketplace)
 	if err != nil {
 		return cli.NewExitError("Could not retrieve resources: "+err.Error(), -1)
 	}
 
-	resources := filterResourcesByAppName(r.Payload, appName)
+	resources := filterResourcesByAppName(r, appName)
 	sort.Sort(resourcesSortByName(resources))
 	cMap, err := fetchCredentials(ctx, marketplace, resources)
 	if err != nil {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -15,8 +15,6 @@ import (
 	"github.com/manifoldco/manifold-cli/errs"
 	"github.com/manifoldco/manifold-cli/prompts"
 	"github.com/manifoldco/manifold-cli/session"
-
-	"github.com/manifoldco/manifold-cli/generated/marketplace/client/resource"
 )
 
 func init() {
@@ -68,13 +66,12 @@ func initDir(cliCtx *cli.Context) error {
 			err.Error(), -1)
 	}
 
-	res, err := mClient.Resource.GetResources(
-		resource.NewGetResourcesParamsWithContext(ctx), nil)
+	res, err := clients.FetchResources(ctx, mClient)
 	if err != nil {
 		return cli.NewExitError("Failed to fetch resource list: "+err.Error(), -1)
 	}
 
-	appNames := fetchUniqueAppNames(res.Payload)
+	appNames := fetchUniqueAppNames(res)
 	newA, appName, err := prompts.SelectCreateAppName(appNames, appName, true)
 	if err != nil {
 		return prompts.HandleSelectError(err, "Could not select app.")

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -17,9 +17,7 @@ import (
 	"github.com/manifoldco/manifold-cli/errs"
 	"github.com/manifoldco/manifold-cli/session"
 
-	"github.com/manifoldco/manifold-cli/generated/marketplace/client/resource"
 	"github.com/manifoldco/manifold-cli/generated/marketplace/models"
-	"github.com/manifoldco/manifold-cli/generated/provisioning/client/operation"
 	pModels "github.com/manifoldco/manifold-cli/generated/provisioning/models"
 )
 
@@ -99,21 +97,19 @@ func list(cliCtx *cli.Context) error {
 	}
 
 	// Get resources
-	res, err := marketplaceClient.Resource.GetResources(
-		resource.NewGetResourcesParamsWithContext(ctx), nil)
+	res, err := clients.FetchResources(ctx, marketplaceClient)
 	if err != nil {
 		return cli.NewExitError("Failed to fetch the list of provisioned "+
 			"resources: "+err.Error(), -1)
 	}
 
 	// Get operations
-	oRes, err := pClient.Operation.GetOperations(
-		operation.NewGetOperationsParamsWithContext(ctx), nil)
+	oRes, err := clients.FetchOperations(ctx, pClient)
 	if err != nil {
 		return cli.NewExitError("Failed to fetch the list of operations: "+err.Error(), -1)
 	}
 
-	resources, statuses := buildResourceList(res.Payload, oRes.Payload)
+	resources, statuses := buildResourceList(res, oRes)
 
 	// Sort resources by name and filter by given app name
 	resources = filterResourcesByAppName(resources, appName)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -17,8 +17,6 @@ import (
 	"github.com/manifoldco/manifold-cli/config"
 	"github.com/manifoldco/manifold-cli/errs"
 	"github.com/manifoldco/manifold-cli/session"
-
-	"github.com/manifoldco/manifold-cli/generated/marketplace/client/resource"
 )
 
 func init() {
@@ -71,13 +69,12 @@ func run(cliCtx *cli.Context) error {
 		return cli.NewExitError("Could not create marketplace client: "+err.Error(), -1)
 	}
 
-	p := resource.NewGetResourcesParamsWithContext(ctx)
-	r, err := marketplace.Resource.GetResources(p, nil)
+	r, err := clients.FetchResources(ctx, marketplace)
 	if err != nil {
 		return cli.NewExitError("Could not retrieve resources: "+err.Error(), -1)
 	}
 
-	resources := filterResourcesByAppName(r.Payload, appName)
+	resources := filterResourcesByAppName(r, appName)
 	cMap, err := fetchCredentials(ctx, marketplace, resources)
 	if err != nil {
 		return cli.NewExitError("Could not retrieve credentials: "+err.Error(), -1)

--- a/specs/billing.yaml
+++ b/specs/billing.yaml
@@ -399,7 +399,7 @@ definitions:
             type: string
         additionalProperties: false
         required:
-        - user_id
+        - provider_id
         - account_id
     additionalProperties: false
     required:
@@ -464,6 +464,8 @@ definitions:
       body:
         type: object
         properties:
+          team_id:
+            $ref: '#/definitions/ID'
           user_id:
             $ref: '#/definitions/ID'
           sources:
@@ -482,6 +484,8 @@ definitions:
   ProfileCreateRequest:
     type: object
     properties:
+      team_id:
+        $ref: '#/definitions/ID'
       user_id:
         $ref: '#/definitions/ID'
       token:
@@ -491,7 +495,6 @@ definitions:
         description: |
           Tokenized source of funds
     required:
-    - user_id
     - token
     additionalProperties: false
   ProfileUpdateRequest:
@@ -599,6 +602,8 @@ definitions:
       occurred_at:
         type: string
         format: date-time
+      team_id:
+        $ref: '#/definitions/ID'
       user_id:
         $ref: '#/definitions/ID'
       provider_id:
@@ -611,7 +616,6 @@ definitions:
     required:
     - event_type
     - event_number
-    - user_id
     - operation_id
     - occurred_at
   credit:

--- a/specs/marketplace.yaml
+++ b/specs/marketplace.yaml
@@ -243,6 +243,8 @@ definitions:
             $ref: '#/definitions/Label'
           app_name:
             $ref: '#/definitions/Name'
+          team_id:
+            $ref: '#/definitions/ID'
           user_id:
             $ref: '#/definitions/ID'
           product_id:
@@ -292,6 +294,8 @@ definitions:
             $ref: '#/definitions/Label'
           app_name:
             $ref: '#/definitions/Name'
+          team_id:
+            $ref: '#/definitions/ID'
           user_id:
             $ref: '#/definitions/ID'
           product_id:
@@ -310,7 +314,6 @@ definitions:
         required:
         - name
         - label
-        - user_id
         - product_id
         - plan_id
         - region_id
@@ -372,8 +375,6 @@ definitions:
       body:
         type: object
         properties:
-          user_id:
-            $ref: '#/definitions/ID'
           resource_id:
             $ref: '#/definitions/ID'
           values:
@@ -383,7 +384,6 @@ definitions:
               must IEEE 1003.1 - 2001 Standard (checked in code).
         additionalProperties: false
         required:
-        - user_id
         - resource_id
         - values
     additionalProperties: false
@@ -408,8 +408,6 @@ definitions:
       body:
         type: object
         properties:
-          user_id:
-            $ref: '#/definitions/ID'
           resource_id:
             $ref: '#/definitions/ID'
           values:
@@ -425,7 +423,6 @@ definitions:
             format: datetime
         additionalProperties: false
         required:
-        - user_id
         - resource_id
         - values
         - created_at

--- a/specs/provisioning.yaml
+++ b/specs/provisioning.yaml
@@ -222,6 +222,8 @@ definitions:
         description: Type of operation this object represents
       resource_id:
         $ref: '#/definitions/ID'
+      team_id:
+        $ref: '#/definitions/ID'
       user_id:
         $ref: '#/definitions/ID'
       message:
@@ -240,7 +242,6 @@ definitions:
     required:
     - type
     - resource_id
-    - user_id
     - message
     - created_at
     - updated_at


### PR DESCRIPTION
We're about to launch Teams on the server side (for the Dashboard). It'll be in beta.
For now we'll just hide anything related to teams from the command line.