### PR TITLE
Plugins alpha implementation

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -13,6 +13,7 @@ import (
 	"github.com/manifoldco/manifold-cli/generated/marketplace/client"
 	resClient "github.com/manifoldco/manifold-cli/generated/marketplace/client/resource"
 	"github.com/manifoldco/manifold-cli/generated/marketplace/models"
+	"github.com/manifoldco/manifold-cli/middleware"
 	"github.com/manifoldco/manifold-cli/prompts"
 )
 
@@ -28,7 +29,7 @@ func init() {
 				Flags: []cli.Flag{
 					appFlag(),
 				},
-				Action: chain(ensureSession, loadDirPrefs, appAddCmd),
+				Action: middleware.Chain(middleware.EnsureSession, middleware.LoadDirPrefs, appAddCmd),
 			},
 			{
 				Name:      "delete",
@@ -37,7 +38,7 @@ func init() {
 				Flags: []cli.Flag{
 					appFlag(),
 				},
-				Action: chain(ensureSession, deleteAppCmd),
+				Action: middleware.Chain(middleware.EnsureSession, deleteAppCmd),
 			},
 		},
 	}

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -17,6 +17,7 @@ import (
 	"github.com/manifoldco/manifold-cli/config"
 	"github.com/manifoldco/manifold-cli/data/catalog"
 	"github.com/manifoldco/manifold-cli/errs"
+	"github.com/manifoldco/manifold-cli/middleware"
 	"github.com/manifoldco/manifold-cli/prompts"
 	"github.com/manifoldco/manifold-cli/session"
 
@@ -32,7 +33,7 @@ func init() {
 		Name:      "create",
 		ArgsUsage: "[product] [name]",
 		Usage:     "Allows a user to create a new resource through Manifold.",
-		Action:    chain(loadDirPrefs, create),
+		Action:    middleware.Chain(middleware.LoadDirPrefs, create),
 		Flags: []cli.Flag{
 			appFlag(),
 			planFlag(),

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -18,6 +18,7 @@ import (
 	pClient "github.com/manifoldco/manifold-cli/generated/provisioning/client"
 	"github.com/manifoldco/manifold-cli/generated/provisioning/client/operation"
 	pModels "github.com/manifoldco/manifold-cli/generated/provisioning/models"
+	"github.com/manifoldco/manifold-cli/middleware"
 	"github.com/manifoldco/manifold-cli/prompts"
 	"github.com/manifoldco/manifold-cli/session"
 )
@@ -27,7 +28,7 @@ func init() {
 		Name:      "delete",
 		ArgsUsage: "[name]",
 		Usage:     "Deletes a resource in Manifold.",
-		Action:    chain(ensureSession, deleteCmd),
+		Action:    middleware.Chain(middleware.EnsureSession, deleteCmd),
 		Flags: []cli.Flag{
 			skipFlag(),
 		},

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -17,6 +17,7 @@ import (
 	"github.com/manifoldco/manifold-cli/clients"
 	"github.com/manifoldco/manifold-cli/config"
 	"github.com/manifoldco/manifold-cli/errs"
+	"github.com/manifoldco/manifold-cli/middleware"
 	"github.com/manifoldco/manifold-cli/session"
 
 	mClient "github.com/manifoldco/manifold-cli/generated/marketplace/client"
@@ -34,7 +35,7 @@ func init() {
 	exportCmd := cli.Command{
 		Name:   "export",
 		Usage:  "Exports all environment variables from all resource",
-		Action: chain(loadDirPrefs, export),
+		Action: middleware.Chain(middleware.LoadDirPrefs, export),
 		Flags: []cli.Flag{
 			formatFlag(formats[0], formatFlagStr),
 			appFlag(),

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -13,6 +13,7 @@ import (
 	"github.com/manifoldco/manifold-cli/config"
 	"github.com/manifoldco/manifold-cli/dirprefs"
 	"github.com/manifoldco/manifold-cli/errs"
+	"github.com/manifoldco/manifold-cli/middleware"
 	"github.com/manifoldco/manifold-cli/prompts"
 	"github.com/manifoldco/manifold-cli/session"
 )
@@ -28,7 +29,7 @@ func init() {
 				Usage: "Overwrite existing app.",
 			},
 		},
-		Action: chain(loadDirPrefs, initDir),
+		Action: middleware.Chain(middleware.LoadDirPrefs, initDir),
 	}
 
 	cmds = append(cmds, initCmd)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -15,6 +15,7 @@ import (
 	"github.com/manifoldco/manifold-cli/config"
 	"github.com/manifoldco/manifold-cli/data/catalog"
 	"github.com/manifoldco/manifold-cli/errs"
+	"github.com/manifoldco/manifold-cli/middleware"
 	"github.com/manifoldco/manifold-cli/session"
 
 	"github.com/manifoldco/manifold-cli/generated/marketplace/models"
@@ -39,7 +40,7 @@ func init() {
 		Name: "list",
 		Usage: "Allows a user to list the status of their provisioned Manifold " +
 			"resources.",
-		Action: chain(loadDirPrefs, list),
+		Action: middleware.Chain(middleware.LoadDirPrefs, list),
 		Flags: []cli.Flag{
 			appFlag(),
 		},

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/urfave/cli"
 
 	"github.com/manifoldco/manifold-cli/config"
+	"github.com/manifoldco/manifold-cli/plugins"
 )
 
 var cmds []cli.Command
@@ -21,6 +23,29 @@ func main() {
 	app.Usage = "A tool making it easy to buy, manage, and integrate developer services into an application."
 	app.Version = config.Version
 	app.Commands = cmds
+
+	app.Action = func(cliCtx *cli.Context) error {
+		// Show help if no arguments passed
+		if len(os.Args) < 2 {
+			cli.ShowAppHelp(cliCtx)
+			return nil
+		}
+
+		// Execute plugin if installed
+		cmd := os.Args[1]
+		success, err := plugins.Run(cmd)
+		if err != nil {
+			return cli.NewExitError("Plugin error: "+err.Error(), -1)
+		}
+		if success {
+			return nil
+		}
+
+		// Otherwise display global help
+		cli.ShowAppHelp(cliCtx)
+		fmt.Println("\nIf you were attempting to use a plugin, it may not be installed.")
+		return nil
+	}
 
 	app.Run(os.Args)
 }

--- a/cmd/plugins.go
+++ b/cmd/plugins.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+
+	"github.com/urfave/cli"
+
+	"github.com/manifoldco/manifold-cli/errs"
+	"github.com/manifoldco/manifold-cli/plugins"
+)
+
+func init() {
+	pluginsCmd := cli.Command{
+		Name:  "plugins",
+		Usage: "Manage installed plugins",
+		Subcommands: []cli.Command{
+			{
+				Name:      "install",
+				Usage:     "Install a new plugin",
+				ArgsUsage: "[repository]",
+				Action:    install,
+			},
+		},
+	}
+
+	cmds = append(cmds, pluginsCmd)
+}
+
+func install(cliCtx *cli.Context) error {
+	pluginsDir, err := plugins.Path()
+	if err != nil {
+		return cli.NewExitError("Failed to install plugin: "+err.Error(), -1)
+	}
+
+	args := cliCtx.Args()
+	if len(args) < 1 {
+		return errs.NewUsageExitError(cliCtx, cli.NewExitError("Missing repository", -1))
+	}
+
+	// Identify the name of the plugin being installed
+	name := plugins.DeriveName(args[0])
+	if err != nil {
+		return cli.NewExitError(err.Error(), -1)
+	}
+	fmt.Printf("Installing plugin `%s`.\n", name)
+
+	// Abort if already exists
+	destinationDir := path.Join(pluginsDir, name)
+	if _, err := os.Stat(destinationDir); !os.IsNotExist(err) {
+		return cli.NewExitError("Plugin already installed.", -1)
+	}
+
+	// Clone to its destination
+	pluginURL := plugins.NormalizeURL(args[0])
+	cmd := exec.Command("git", "clone", pluginURL, destinationDir)
+	err = cmd.Run()
+	if err != nil {
+		return cli.NewExitError("Failed to clone plugin: "+err.Error(), -1)
+	}
+
+	// Initialize the config file
+	newFile, err := os.Create(path.Join(destinationDir, ".config.json"))
+	if err != nil {
+		return cli.NewExitError("Failed to create config file: "+err.Error(), -1)
+	}
+	newFile.Close()
+
+	fmt.Println("Done.")
+	fmt.Println("")
+
+	// Finally output the Help text
+	return plugins.Help(name)
+}

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -14,6 +14,7 @@ import (
 	"github.com/manifoldco/manifold-cli/generated/marketplace/client"
 	resClient "github.com/manifoldco/manifold-cli/generated/marketplace/client/resource"
 	"github.com/manifoldco/manifold-cli/generated/marketplace/models"
+	"github.com/manifoldco/manifold-cli/middleware"
 	"github.com/manifoldco/manifold-cli/prompts"
 )
 
@@ -26,7 +27,7 @@ func init() {
 			appFlag(),
 			nameFlag(),
 		},
-		Action: chain(ensureSession, loadDirPrefs, rename),
+		Action: middleware.Chain(middleware.EnsureSession, middleware.LoadDirPrefs, rename),
 	}
 
 	cmds = append(cmds, renameCmd)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -16,6 +16,7 @@ import (
 	"github.com/manifoldco/manifold-cli/clients"
 	"github.com/manifoldco/manifold-cli/config"
 	"github.com/manifoldco/manifold-cli/errs"
+	"github.com/manifoldco/manifold-cli/middleware"
 	"github.com/manifoldco/manifold-cli/session"
 )
 
@@ -23,7 +24,7 @@ func init() {
 	runCmd := cli.Command{
 		Name:   "run",
 		Usage:  "Run a process and inject secrets into its environment",
-		Action: chain(loadDirPrefs, run),
+		Action: middleware.Chain(middleware.LoadDirPrefs, run),
 		Flags: []cli.Flag{
 			appFlag(),
 		},

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -15,6 +15,7 @@ import (
 	"github.com/manifoldco/manifold-cli/config"
 	catalogcache "github.com/manifoldco/manifold-cli/data/catalog"
 	"github.com/manifoldco/manifold-cli/errs"
+	"github.com/manifoldco/manifold-cli/middleware"
 	"github.com/manifoldco/manifold-cli/prompts"
 	"github.com/manifoldco/manifold-cli/session"
 
@@ -34,7 +35,7 @@ func init() {
 		Name:      "update",
 		ArgsUsage: "[label]",
 		Usage:     "Allows a user to update a resource in Manifold",
-		Action:    chain(ensureSession, loadDirPrefs, updateResourceCmd),
+		Action:    middleware.Chain(middleware.EnsureSession, middleware.LoadDirPrefs, updateResourceCmd),
 		Flags: []cli.Flag{
 			nameFlag(),
 			appFlag(),

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -1,4 +1,4 @@
-package main
+package middleware
 
 import (
 	"context"
@@ -15,9 +15,9 @@ import (
 	"github.com/manifoldco/manifold-cli/session"
 )
 
-// chain allows easy sequential calling of BeforeFuncs and AfterFuncs.
+// Chain allows easy sequential calling of BeforeFuncs and AfterFuncs.
 // chain will exit on the first error seen.
-func chain(funcs ...func(*cli.Context) error) func(*cli.Context) error {
+func Chain(funcs ...func(*cli.Context) error) func(*cli.Context) error {
 	return func(ctx *cli.Context) error {
 
 		for _, f := range funcs {
@@ -31,8 +31,8 @@ func chain(funcs ...func(*cli.Context) error) func(*cli.Context) error {
 	}
 }
 
-// loadDirPrefs loads argument values from the .torus.json file
-func loadDirPrefs(ctx *cli.Context) error {
+// LoadDirPrefs loads argument values from the .torus.json file
+func LoadDirPrefs(ctx *cli.Context) error {
 	d, err := dirprefs.Load(true)
 	if err != nil {
 		return err
@@ -41,7 +41,8 @@ func loadDirPrefs(ctx *cli.Context) error {
 	return reflectArgs(ctx, d, "json")
 }
 
-func ensureSession(_ *cli.Context) error {
+// EnsureSession checks that the user has an active session
+func EnsureSession(_ *cli.Context) error {
 	ctx := context.Background()
 
 	cfg, err := config.Load()

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -1,0 +1,234 @@
+package plugins
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"os/exec"
+	"os/user"
+	"path"
+	"strings"
+)
+
+const (
+	directory              = ".manifold"
+	permissions            = 0700
+	pluginPrefix           = "manifold-cli-"
+	pluginConfigFilename   = ".config.json"
+	pluginConfigPermission = 0644
+	slash                  = "/"
+)
+
+// ErrFailedToRead is returned when you the plugins directory cannot be read
+var ErrFailedToRead = errors.New("Failed to read plugins directory")
+
+// ErrMissingHomeDir represents an error when a home directory could not be found
+var ErrMissingHomeDir = errors.New("Could not find Home Directory")
+
+// ErrBadPluginRepository represents an error when the plugin url is invalidu
+var ErrBadPluginRepository = errors.New("Invalid repository URL")
+
+// Path returns the plugin directory's path
+func Path() (string, error) {
+	u, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+
+	if u.HomeDir == "" {
+		return "", ErrMissingHomeDir
+	}
+
+	return path.Join(u.HomeDir, directory), nil
+}
+
+// Executable returns the executable path
+func Executable(cmd string) (string, error) {
+	pluginsDir, err := Path()
+	if err != nil {
+		return "", err
+	}
+
+	// TODO: we need to infer the architecture being user
+	// and call the proper binary in the plugin repository
+	return path.Join(pluginsDir, cmd, "bin", strings.Replace(cmd, pluginPrefix, "", 1)), nil
+}
+
+// List returns a list of available plugin commands
+func List() ([]string, error) {
+	var plugs []string
+
+	// Construct the plugins directory path
+	pluginsDir, err := Path()
+	if err != nil {
+		return plugs, err
+	}
+
+	// Create the directory if it does not exist
+	if _, err := os.Stat(pluginsDir); os.IsNotExist(err) {
+		_ = os.Mkdir(pluginsDir, permissions)
+		return plugs, nil
+	}
+
+	// Read the contents of the directory
+	files, err := ioutil.ReadDir(pluginsDir)
+	if err != nil {
+		return plugs, ErrFailedToRead
+	}
+	for _, f := range files {
+		plugs = append(plugs, f.Name())
+	}
+
+	return plugs, nil
+}
+
+// NormalizeURL returns a normalized git url
+func NormalizeURL(pluginURL string) string {
+	u, err := url.Parse(pluginURL)
+	if err != nil {
+		return ""
+	}
+	if strings.HasSuffix(u.Path, slash) {
+		u.Path = u.Path[:len(u.Path)-1]
+	}
+	pluginURL = fmt.Sprintf("git@%s%s", u.Host, u.Path)
+	if strings.Count(pluginURL, slash) == 2 {
+		pluginURL = strings.Replace(pluginURL, slash, ":", 1)
+	}
+	return pluginURL
+}
+
+// DeriveName returns the name of the plugin based on git repo url
+func DeriveName(pluginURL string) string {
+	repoURL := NormalizeURL(pluginURL)
+	repoURL = repoURL[strings.Index(repoURL, "/")+1:]
+	return strings.Replace(repoURL, ".git", "", 1)
+}
+
+// Help executes the plugin's help command
+func Help(cmd string) error {
+	// List installed plugins
+	plugs, err := List()
+	if err != nil {
+		return err
+	}
+
+	for _, p := range plugs {
+		if cmd == p {
+			// Identify the executable path for the plugin
+			binPath, err := Executable(cmd)
+			if err != nil {
+				return err
+			}
+
+			// Construct execution of the plugin binary
+			proc := exec.Command(binPath, "--help")
+			proc.Stdout = os.Stdout
+			proc.Stderr = os.Stderr
+
+			// Execute
+			return proc.Run()
+		}
+	}
+
+	// Plugin not found, no error
+	return errors.New("Plugin not found")
+}
+
+// Run executes the requested plugin command and redirects stdout
+func Run(cmd string) (bool, error) {
+	// List installed plugins
+	plugs, err := List()
+	if err != nil {
+		return false, err
+	}
+
+	for _, p := range plugs {
+		if cmd == strings.Replace(p, pluginPrefix, "", 1) {
+			// Identify the executable path for the plugin
+			binPath, err := Executable(p)
+			if err != nil {
+				return false, err
+			}
+
+			// Construct execution of the plugin binary
+			var pluginArgs []string
+			pluginArgs = append(pluginArgs, os.Args[2:]...)
+			proc := exec.Command(binPath, pluginArgs...)
+			proc.Stdout = os.Stdout
+			proc.Stderr = os.Stderr
+
+			// Execute
+			err = proc.Run()
+			if err != nil {
+				return false, err
+			}
+			return true, nil
+		}
+	}
+
+	// Plugin not found, no error
+	return false, nil
+}
+
+// configPath returns the plugin config file path
+func configPath(plugin string) (string, error) {
+	pluginsDir, err := Path()
+	if err != nil {
+		return "", err
+	}
+
+	return path.Join(pluginsDir, pluginPrefix+plugin, pluginConfigFilename), nil
+}
+
+// Config returns the key value configuration found in the plugin directory
+func Config(plugin string) (map[string]string, string, error) {
+	// TODO: make this map[string]interface to allow for subkeys
+	conf := make(map[string]string)
+
+	confPath, err := configPath(plugin)
+	if err != nil {
+		return conf, "", err
+	}
+
+	// Create the .config.json if it doesn't exist
+	_, err = os.Stat(confPath)
+	if os.IsNotExist(err) {
+		_, err := os.Create(confPath)
+		return conf, confPath, err
+	}
+
+	// Read the config file contents
+	contents, err := ioutil.ReadFile(confPath)
+	if err != nil || len(contents) < 1 {
+		return conf, confPath, err
+	}
+
+	err = json.Unmarshal(contents, &conf)
+	return conf, confPath, err
+}
+
+// SetConfig sets a key on the config map
+func SetConfig(plugin, key, value string) (map[string]string, error) {
+	conf, confPath, err := Config(plugin)
+	if err != nil {
+		return conf, err
+	}
+
+	conf[key] = value
+	confJSON, _ := json.Marshal(conf)
+	file, err := os.OpenFile(confPath, os.O_RDWR, pluginConfigPermission)
+	defer file.Close()
+	if err != nil {
+		return conf, err
+	}
+	_, err = file.Write(confJSON)
+	if err != nil {
+		return conf, err
+	}
+
+	return conf, nil
+}


### PR DESCRIPTION
I've had some ideas around things I'd want to build for the CLI that probably shouldn't just be built-in commands, but plugins that people selectively install.

One way I figured we could do them would be to simply package the plugins as their own standalone `urfave/cli` apps that import any packages from `manifold-cli` that they need. Then we simply package them in a known way to the CLI and execute the binary with appropriate args.

This is the example of that implementation. Thoughts?
Here's a gist of example output: https://gist.github.com/jeffandersen/a93648cbf70dfe242615751b76ccbe80