### PR TITLE
Fix bug with list cmd regarding nil team ID

### DIFF
--- a/clients/resources.go
+++ b/clients/resources.go
@@ -22,7 +22,7 @@ func FetchOperations(ctx context.Context, c *pClient.Provisioning) ([]*pModels.O
 	var results []*pModels.Operation
 	for _, o := range res.Payload {
 		// TODO: remove this once CLI has first-class Teams support
-		if !o.Body.TeamID().IsEmpty() {
+		if o.Body.TeamID() != nil {
 			continue
 		}
 		results = append(results, o)


### PR DESCRIPTION
The spec changes mean that IsEmpty on a nil ID results in a panic.
This resolves that for operations list (already corrected in master for resources list)