### PR TITLE
Change help output name

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,8 +16,8 @@ func main() {
 	}
 
 	app := cli.NewApp()
-	app.Name = "manifold-cli"
-	app.HelpName = "manifold-cli"
+	app.Name = "manifold"
+	app.HelpName = "manifold"
 	app.Usage = "A tool making it easy to buy, manage, and integrate developer services into an application."
 	app.Version = config.Version
 	app.Commands = cmds


### PR DESCRIPTION
We install the binary as `manifold` to the user's path. Lets not call it `manifold-cli` in help.