### PR TITLE
Add manifold app add for adding resource to app

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -77,6 +77,9 @@ func appAddCmd(cliCtx *cli.Context) error {
 	}
 
 	resourceIdx, _, err := prompts.SelectResource(res, resourceLabel)
+	if err != nil {
+		return prompts.HandleSelectError(err, "Could not select Resource")
+	}
 	resource := res[resourceIdx]
 
 	if appName == "" {


### PR DESCRIPTION
This adds `manifold app add` to add an existing resource to an app.

Resolves manifoldco/engineering#2646