### PR TITLE
Fix panic on manifold init if no resources have apps

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -72,6 +72,10 @@ func initDir(cliCtx *cli.Context) error {
 	}
 
 	appNames := fetchUniqueAppNames(res)
+	if len(appNames) == 0 {
+		return errs.ErrNoApps
+	}
+
 	newA, appName, err := prompts.SelectCreateAppName(appNames, appName, true)
 	if err != nil {
 		return prompts.HandleSelectError(err, "Could not select app.")


### PR DESCRIPTION
If no resources exist, `manifold init` panics because it tries to create Select prompt with no apps to show.