### PR TITLE
Add CLI args validation

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -55,7 +55,15 @@ func init() {
 
 func create(cliCtx *cli.Context) error {
 	ctx := context.Background()
-	args := cliCtx.Args()
+
+	if err := maxOptionalArgsLength(cliCtx, 1); err != nil {
+		return err
+	}
+
+	resourceName, err := optionalArgName(cliCtx, 0, "resource")
+	if err != nil {
+		return err
+	}
 
 	dontWait := cliCtx.Bool("no-wait")
 	appName, err := validateName(cliCtx, "app")
@@ -76,19 +84,6 @@ func create(cliCtx *cli.Context) error {
 	regionLabel, err := validateLabel(cliCtx, "region")
 	if err != nil {
 		return err
-	}
-
-	if len(args) > 1 {
-		return errs.NewUsageExitError(cliCtx, errs.ErrTooManyArgs)
-	}
-
-	resourceName := ""
-	if len(args) == 1 {
-		resourceName = args[0]
-		l := manifold.Name(resourceName)
-		if err := l.Validate(nil); err != nil {
-			return errs.NewUsageExitError(cliCtx, errs.ErrInvalidResourceName)
-		}
 	}
 
 	custom := cliCtx.Bool("custom")

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -39,21 +39,16 @@ func init() {
 
 func deleteCmd(cliCtx *cli.Context) error {
 	ctx := context.Background()
-	args := cliCtx.Args()
 
 	dontWait := cliCtx.Bool("no-wait")
 
-	resourceLabel := ""
-	if len(args) > 1 {
-		return errs.NewUsageExitError(cliCtx, errs.ErrTooManyArgs)
+	if err := maxOptionalArgsLength(cliCtx, 1); err != nil {
+		return err
 	}
 
-	if len(args) > 0 {
-		resourceLabel = args[0]
-		l := manifold.Label(resourceLabel)
-		if err := l.Validate(nil); err != nil {
-			return errs.NewUsageExitError(cliCtx, errs.ErrInvalidResourceName)
-		}
+	resourceLabel, err := optionalArgLabel(cliCtx, 0, "resource")
+	if err != nil {
+		return err
 	}
 
 	cfg, err := config.Load()

--- a/cmd/team.go
+++ b/cmd/team.go
@@ -40,20 +40,16 @@ func init() {
 
 func createTeamCmd(cliCtx *cli.Context) error {
 	ctx := context.Background()
-	args := cliCtx.Args()
 
-	teamName := ""
-	if len(args) == 1 {
-		teamName = args[0]
-		l := manifold.Name(teamName)
-		if err := l.Validate(nil); err != nil {
-			return cli.NewExitError("You've provided an nvalid team name", -1)
-		}
+	if err := maxOptionalArgsLength(cliCtx, 1); err != nil {
+		return err
 	}
 
-	if len(args) > 1 {
-		return errs.ErrTooManyArgs
+	teamName, err := optionalArgLabel(cliCtx, 0, "team")
+	if err != nil {
+		return err
 	}
+
 	cfg, err := config.Load()
 	if err != nil {
 		return cli.NewExitError(fmt.Sprintf("Could not load configuration: %s", err), -1)

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -49,23 +49,17 @@ func init() {
 
 func updateResourceCmd(cliCtx *cli.Context) error {
 	ctx := context.Background()
-	args := cliCtx.Args()
+
+	if err := maxOptionalArgsLength(cliCtx, 1); err != nil {
+		return err
+	}
+
+	resourceLabel, err := optionalArgLabel(cliCtx, 0, "resource")
+	if err != nil {
+		return err
+	}
 
 	dontWait := cliCtx.Bool("no-wait")
-
-	resourceLabel := ""
-
-	if len(args) > 2 {
-		return errs.NewUsageExitError(cliCtx, errs.ErrTooManyArgs)
-	}
-
-	if len(args) > 0 {
-		resourceLabel = args[0]
-		l := manifold.Label(resourceLabel)
-		if err := l.Validate(nil); err != nil {
-			return errs.NewUsageExitError(cliCtx, errs.ErrInvalidResourceName)
-		}
-	}
 
 	cfg, err := config.Load()
 	if err != nil {

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -51,3 +51,49 @@ func requiredLabel(cliCtx *cli.Context, option string) (string, error) {
 
 	return validateLabel(cliCtx, option)
 }
+
+func optionalArgLabel(cliCtx *cli.Context, idx int, name string) (string, error) {
+	args := cliCtx.Args()
+
+	if len(args) < idx+1 {
+		return "", nil
+	}
+
+	val := args[idx]
+	l := manifold.Label(val)
+	if err := l.Validate(nil); err != nil {
+		return "", errs.NewUsageExitError(cliCtx, cli.NewExitError(
+			fmt.Sprintf("You've provided an invalid %s!", name), -1,
+		))
+	}
+
+	return val, nil
+}
+
+func optionalArgName(cliCtx *cli.Context, idx int, name string) (string, error) {
+	args := cliCtx.Args()
+
+	if len(args) < idx+1 {
+		return "", nil
+	}
+
+	val := args[idx]
+	n := manifold.Name(val)
+	if err := n.Validate(nil); err != nil {
+		return "", errs.NewUsageExitError(cliCtx, cli.NewExitError(
+			fmt.Sprintf("You've provided an invalid %s name", name), -1,
+		))
+	}
+
+	return val, nil
+}
+
+func maxOptionalArgsLength(cliCtx *cli.Context, size int) error {
+	args := cliCtx.Args()
+
+	if len(args) > size {
+		return errs.ErrTooManyArgs
+	}
+
+	return nil
+}


### PR DESCRIPTION
In the same vein as manifoldco/manifold-cli#49, add arg validation to avoid defining a bunch of errors and clean up validation in the cli handlers