### PR TITLE
Consistent cmds usage

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -19,7 +19,7 @@ import (
 func init() {
 	appCmd := cli.Command{
 		Name:  "apps",
-		Usage: "Manages an App in Manifold",
+		Usage: "Manage an App in Manifold",
 		Subcommands: []cli.Command{
 			{
 				Name:      "add",

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -32,7 +32,7 @@ func init() {
 	createCmd := cli.Command{
 		Name:      "create",
 		ArgsUsage: "[name]",
-		Usage:     "Allows a user to create a new resource through Manifold.",
+		Usage:     "Allow a user to create a new resource through Manifold",
 		Action:    middleware.Chain(middleware.LoadDirPrefs, create),
 		Flags: []cli.Flag{
 			appFlag(),

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -27,7 +27,7 @@ func init() {
 	deleteCmd := cli.Command{
 		Name:      "delete",
 		ArgsUsage: "[name]",
-		Usage:     "Deletes a resource in Manifold.",
+		Usage:     "Delete a resource in Manifold",
 		Action:    middleware.Chain(middleware.EnsureSession, deleteCmd),
 		Flags: []cli.Flag{
 			skipFlag(),

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -31,7 +31,7 @@ func init() {
 	formatFlagStr := fmt.Sprintf("Export format of the secrets (%s)", strings.Join(formats, ", "))
 	exportCmd := cli.Command{
 		Name:   "export",
-		Usage:  "Exports all environment variables from all resource",
+		Usage:  "Export all environment variables from all resources",
 		Action: middleware.Chain(middleware.LoadDirPrefs, export),
 		Flags: []cli.Flag{
 			formatFlag(formats[0], formatFlagStr),

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -38,8 +38,8 @@ func (r resourcesSortByName) Less(i, j int) bool {
 func init() {
 	listCmd := cli.Command{
 		Name: "list",
-		Usage: "Allows a user to list the status of their provisioned Manifold " +
-			"resources.",
+		Usage: "Allow a user to list the status of their provisioned Manifold " +
+			"resources",
 		Action: middleware.Chain(middleware.LoadDirPrefs, list),
 		Flags: []cli.Flag{
 			appFlag(),

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -16,7 +16,7 @@ import (
 func init() {
 	loginCmd := cli.Command{
 		Name:   "login",
-		Usage:  "Allows a user to login to their account",
+		Usage:  "Allow a user to login to their account",
 		Action: login,
 	}
 

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -15,7 +15,7 @@ import (
 func init() {
 	logoutCmd := cli.Command{
 		Name:   "logout",
-		Usage:  "Allows a user to logout of their Manifold session",
+		Usage:  "Allow a user to logout of their Manifold session",
 		Action: logout,
 	}
 

--- a/cmd/signup.go
+++ b/cmd/signup.go
@@ -16,7 +16,7 @@ import (
 func init() {
 	signupCmd := cli.Command{
 		Name:   "signup",
-		Usage:  "Allows a user to create a new account",
+		Usage:  "Allow a user to create a new account",
 		Action: signup,
 	}
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -34,7 +34,7 @@ func init() {
 	updateCmd := cli.Command{
 		Name:      "update",
 		ArgsUsage: "[label]",
-		Usage:     "Allows a user to update a resource in Manifold",
+		Usage:     "Allow a user to update a resource in Manifold",
 		Action:    middleware.Chain(middleware.EnsureSession, middleware.LoadDirPrefs, updateResourceCmd),
 		Flags: []cli.Flag{
 			nameFlag(),


### PR DESCRIPTION
Following the same usage from `torus`: verbs on first person and no period at the end. The only exception is the default `help` command:

```
Shows a list of commands or help for one command
```