### PR TITLE
Add manifold teams leave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Rename app command to apps
 - Add 'team create' to create a Team
 - Add 'team update' to update a Team
+- Add 'team leave' to leave a Team
 - Add 'switch' to switch Teams, so interact with a team's resources
 
 ### Fixed

--- a/clients/teams.go
+++ b/clients/teams.go
@@ -23,3 +23,21 @@ func FetchTeams(ctx context.Context, c *iClient.Identity) ([]*iModels.Team, erro
 
 	return results, nil
 }
+
+// FetchMemberships returns all memberships for the authenticated user
+func FetchMemberships(ctx context.Context, c *iClient.Identity) ([]iModels.TeamMembership, error) {
+	params := team.NewGetMembershipsParamsWithContext(ctx)
+	res, err := c.Team.GetMemberships(params, nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var results []iModels.TeamMembership
+
+	for _, m := range res.Payload {
+		results = append(results, *m)
+	}
+
+	return results, nil
+}


### PR DESCRIPTION
Add `manifold teams leave` to remove user membership from a team.

```
$ manifold teams leave                                                            
✔ Select Team: test2 (test-2)                                                  
You have left the team "test2"
```

Resolves: https://github.com/manifoldco/engineering/issues/2774