### PR TITLE
Change credit card number and cvv lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Add a newline after signup output, so it won't mess up the prompt.
+- Credit Card number can be between 12 and 19 digits and cvv either 3 or 4.
 
 ## [0.2.6] - 2017-08-16
 

--- a/prompts/prompts.go
+++ b/prompts/prompts.go
@@ -522,7 +522,7 @@ func getPlanCost(p *cModels.Plan) string {
 }
 
 func isCard(raw string) error {
-	if govalidator.StringLength(raw, "16", "16") && govalidator.IsNumeric(raw) {
+	if govalidator.StringLength(raw, "12", "19") && govalidator.IsNumeric(raw) {
 		return nil
 	}
 
@@ -538,7 +538,7 @@ func isExpiry(raw string) error {
 }
 
 func isCVV(raw string) error {
-	if govalidator.StringLength(raw, "3", "3") && govalidator.IsNumeric(raw) {
+	if govalidator.StringLength(raw, "3", "4") && govalidator.IsNumeric(raw) {
 		return nil
 	}
 


### PR DESCRIPTION
AmEx for example has 15 digits and 4 for cvv

Stripe has a few examples ranging from 12 to 16: https://stripe.com/docs/testing

Apparently up to 19 digits is acceptable: https://en.wikipedia.org/wiki/Payment_card_number