### PR TITLE
Make command descriptions more consistent

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -19,12 +19,12 @@ import (
 func init() {
 	appCmd := cli.Command{
 		Name:  "apps",
-		Usage: "Manage an App in Manifold",
+		Usage: "Manage your apps",
 		Subcommands: []cli.Command{
 			{
 				Name:      "add",
 				ArgsUsage: "[label]",
-				Usage:     "Add a resource to an app in Manifold.",
+				Usage:     "Add a resource to an app",
 				Flags: []cli.Flag{
 					appFlag(),
 				},
@@ -33,7 +33,7 @@ func init() {
 			{
 				Name:      "delete",
 				ArgsUsage: "[label]",
-				Usage:     "Removes a resource from an app in Manifold.",
+				Usage:     "Removes a resource from an app",
 				Flags: []cli.Flag{
 					appFlag(),
 				},

--- a/cmd/billing.go
+++ b/cmd/billing.go
@@ -24,7 +24,7 @@ func init() {
 		Subcommands: []cli.Command{
 			{
 				Name:   "add",
-				Usage:  "Add a credit",
+				Usage:  "Add a credit card",
 				Action: add,
 			},
 			{

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -26,7 +26,7 @@ func init() {
 			{
 				Name:      "set",
 				ArgsUsage: "<key=value...>",
-				Usage:     "Set one or more config values on a custom resource.",
+				Usage:     "Set one or more config values on a custom resource",
 				Flags: []cli.Flag{
 					resourceFlag(),
 				},
@@ -35,7 +35,7 @@ func init() {
 			{
 				Name:      "unset",
 				ArgsUsage: "<key...>",
-				Usage:     "Unset one or more config values on a custom resource.",
+				Usage:     "Unset one or more config values on a custom resource",
 				Flags: []cli.Flag{
 					resourceFlag(),
 				},

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -32,7 +32,7 @@ func init() {
 	createCmd := cli.Command{
 		Name:      "create",
 		ArgsUsage: "[name]",
-		Usage:     "Allow a user to create a new resource through Manifold",
+		Usage:     "Create a new resource",
 		Action:    middleware.Chain(middleware.LoadDirPrefs, create),
 		Flags: []cli.Flag{
 			appFlag(),

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -27,7 +27,7 @@ func init() {
 	deleteCmd := cli.Command{
 		Name:      "delete",
 		ArgsUsage: "[name]",
-		Usage:     "Delete a resource in Manifold",
+		Usage:     "Delete a resource",
 		Action:    middleware.Chain(middleware.EnsureSession, deleteCmd),
 		Flags: []cli.Flag{
 			skipFlag(),

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -25,7 +25,7 @@ func init() {
 			appFlag(),
 			cli.BoolFlag{
 				Name:  "force, f",
-				Usage: "Overwrite existing app.",
+				Usage: "Overwrite existing app",
 			},
 		},
 		Action: middleware.Chain(middleware.LoadDirPrefs, initDir),

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -37,9 +37,8 @@ func (r resourcesSortByName) Less(i, j int) bool {
 
 func init() {
 	listCmd := cli.Command{
-		Name: "list",
-		Usage: "Allow a user to list the status of their provisioned Manifold " +
-			"resources",
+		Name:   "list",
+		Usage:  "List the status of your provisioned resources",
 		Action: middleware.Chain(middleware.LoadDirPrefs, list),
 		Flags: []cli.Flag{
 			appFlag(),

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -16,7 +16,7 @@ import (
 func init() {
 	loginCmd := cli.Command{
 		Name:   "login",
-		Usage:  "Allow a user to login to their account",
+		Usage:  "Log in to your account",
 		Action: login,
 	}
 

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -15,7 +15,7 @@ import (
 func init() {
 	logoutCmd := cli.Command{
 		Name:   "logout",
-		Usage:  "Allow a user to logout of their Manifold session",
+		Usage:  "Log out of your account",
 		Action: logout,
 	}
 

--- a/cmd/signup.go
+++ b/cmd/signup.go
@@ -16,7 +16,7 @@ import (
 func init() {
 	signupCmd := cli.Command{
 		Name:   "signup",
-		Usage:  "Allow a user to create a new account",
+		Usage:  "Create a new account",
 		Action: signup,
 	}
 

--- a/cmd/team.go
+++ b/cmd/team.go
@@ -22,16 +22,18 @@ import (
 func init() {
 	appCmd := cli.Command{
 		Name:  "teams",
-		Usage: "Manage Teams in Manifold",
+		Usage: "Manage your teams",
 		Subcommands: []cli.Command{
 			{
-				Name:      "create",
-				ArgsUsage: "[name]",
-				Action:    middleware.Chain(middleware.EnsureSession, createTeamCmd),
+				Name:        "create",
+				Description: "Create a new team",
+				ArgsUsage:   "[name]",
+				Action:      middleware.Chain(middleware.EnsureSession, createTeamCmd),
 			},
 			{
-				Name:      "update",
-				ArgsUsage: "[label]",
+				Name:        "update",
+				Description: "Update an existing team",
+				ArgsUsage:   "[label]",
 				Flags: []cli.Flag{
 					nameFlag(),
 				},

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -34,7 +34,7 @@ func init() {
 	updateCmd := cli.Command{
 		Name:      "update",
 		ArgsUsage: "[label]",
-		Usage:     "Allow a user to update a resource in Manifold",
+		Usage:     "Update a resource",
 		Action:    middleware.Chain(middleware.EnsureSession, middleware.LoadDirPrefs, updateResourceCmd),
 		Flags: []cli.Flag{
 			nameFlag(),


### PR DESCRIPTION
Ran the CLI for the first time today and noticed some inconsistencies in the command descriptions; this fixes that.

After:

```
./manifold
NAME:
   manifold - A tool making it easy to buy, manage, and integrate developer services into an application.

USAGE:
   manifold [global options] command [command options] [arguments...]

VERSION:
   0.2.6-50-g6a4c892

COMMANDS:
     apps     Manage your apps
     billing  Manage your billing information
     config   View and modify resource configuration
     create   Create a new resource
     delete   Delete a resource
     export   Export all environment variables from all resources
     init     Initialize the current directory for a specified app
     list     List the status of your provisioned resources
     login    Log in to your account
     logout   Log out of your account
     plugins  Manage installed plugins
     rename   Rename a resource label
     run      Run a process and inject secrets into its environment
     signup   Create a new account
     switch   Switch to a team context
     teams    Manage your teams
     update   Update a resource
     version  Display version of this tool
     help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --help, -h     show help
   --version, -v  print the version
```