### PR TITLE
Make the map before attempting to set a key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Add a newline after signup output, so it won't mess up the prompt.
 - Credit Card number can be between 12 and 19 digits and cvv either 3 or 4.
+- Plugin config initializes map before setting if it doesn't exist
 
 ## [0.2.6] - 2017-08-16
 

--- a/config/config.go
+++ b/config/config.go
@@ -39,6 +39,9 @@ const (
 // ErrMissingHomeDir represents an error when a home directory could not be found
 var ErrMissingHomeDir = errors.New("Could not find Home Directory")
 
+// ErrPluginNotFound is returned if a particular plugin doesn't exist in the yaml when requested
+var ErrPluginNotFound = errors.New("Plugin not found")
+
 // ErrWrongConfigPermissions represents an error when the config permissions
 // are incorrect.
 var ErrWrongConfigPermissions = errors.New(
@@ -169,6 +172,9 @@ type ManifoldYaml struct {
 
 // GetPlugin retrieves plugins config for the given plugin name
 func (m ManifoldYaml) GetPlugin(name string, conf interface{}) error {
+	if m.Plugins == nil {
+		return ErrPluginNotFound
+	}
 	if _, ok := m.Plugins[name]; ok {
 		// TODO: Can this just be reflected into the interface?
 		str, err := yaml.Marshal(m.Plugins[name])
@@ -181,11 +187,14 @@ func (m ManifoldYaml) GetPlugin(name string, conf interface{}) error {
 		}
 		return nil
 	}
-	return errors.New("Plugin not found")
+	return ErrPluginNotFound
 }
 
 // SavePlugin writes the ManifoldYaml values for a specific plugin name
 func (m *ManifoldYaml) SavePlugin(name string, conf interface{}) error {
+	if m.Plugins == nil {
+		m.Plugins = make(map[string]interface{})
+	}
 	m.Plugins[name] = conf
 	return m.Save()
 }


### PR DESCRIPTION
- Exposes an err that I need to be able to check for in plugins
- Ensures we don't try to set on an uninitialized map