### PR TITLE
Define the ManifoldYaml path if doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add a newline after signup output, so it won't mess up the prompt.
 - Credit Card number can be between 12 and 19 digits and cvv either 3 or 4.
 - Plugin config initializes map before setting if it doesn't exist
+- Plugin config defines the .manifold.yml path prior to saving if not defined
 
 ## [0.2.6] - 2017-08-16
 

--- a/config/config.go
+++ b/config/config.go
@@ -206,7 +206,16 @@ func (m *ManifoldYaml) Save() error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(m.Path, yml, requiredPermissions)
+	path := m.Path
+	if path == "" {
+		// Set the yaml in the current directory if path is not known
+		wd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		path = filepath.Join(wd, YamlFilename)
+	}
+	err = ioutil.WriteFile(path, yml, requiredPermissions)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
If the ManifoldYaml object is created, but the files doesn't exist yet, and then Save is called then it would Panic because the path would not yet be defined.

This ensures that we have a path to use.