### PR TITLE
Fix spacing for long names on team list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Update resource selects to be label-focused
 - Make plugin execution architecture aware
 - Output adjusted for team selector
+- Ensure columns accept long names in Teams list
 
 ## [0.3.0] - 2017-08-29
 

--- a/cmd/teams.go
+++ b/cmd/teams.go
@@ -207,9 +207,11 @@ func listTeamCmd(cliCtx *cli.Context) error {
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 8, ' ', 0)
 
-	bold := color.New(color.Bold).SprintFunc()
+	bold := color.New(color.Faint).SprintFunc()
+	str := color.New().SprintFunc() // TODO: find solution for tabwriter color support and remove this
 
-	fmt.Fprintf(w, "%s\t%s\n\n", bold("Name"), bold("Members"))
+	fmt.Fprintf(w, "%s\t%s\n", bold("Name"), bold("Members"))
+	fmt.Fprintf(w, "%s\t%s\n", str(""), str(""))
 
 	sort.Slice(teams, func(i int, j int) bool {
 		a := strings.ToLower(teams[i].Name)
@@ -218,7 +220,7 @@ func listTeamCmd(cliCtx *cli.Context) error {
 	})
 
 	for _, team := range teams {
-		fmt.Fprintf(w, "%s\t%d\n", team.Name, team.Members)
+		fmt.Fprintf(w, "%s\t%s\n", str(team.Name), str(team.Members))
 	}
 	return w.Flush()
 }


### PR DESCRIPTION
```$ ./bin/manifold teams list
Name                                                                        Members

james                                                                        1
jeff                                                                         1
Manifold                                                                     5
this is the team name that never ends yes it goes on and on my friend        1
```

Doesn't entirely fix it. But is a stop-gap to figuring out proper tabwriter support for colors.