### PR TITLE
Change filtering of resources and operations, update list cmd to filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - `view` command to show project label instead of app name
 - `update` command to accept project label instead of app name
+- Fetching resources or operations with nil team returns personal account
+- `list` now adheres to team context for operations
 
 ### Removed
 

--- a/clients/resources.go
+++ b/clients/resources.go
@@ -23,8 +23,8 @@ func FetchOperations(ctx context.Context, c *pClient.Provisioning, teamID *manif
 
 	var results []*pModels.Operation
 	for _, o := range res.Payload {
-		if teamID != nil && o.Body.TeamID() != nil && teamID.String() == o.Body.TeamID().String() ||
-			teamID == nil && o.Body.TeamID() == nil {
+		if (teamID == nil && o.Body.TeamID() == nil) ||
+			(teamID != nil && o.Body.TeamID() != nil && teamID.String() == o.Body.TeamID().String()) {
 			results = append(results, o)
 		}
 	}
@@ -41,8 +41,8 @@ func FetchResources(ctx context.Context, c *mClient.Marketplace, teamID *manifol
 
 	var results []*mModels.Resource
 	for _, r := range res.Payload {
-		if teamID != nil && r.Body.TeamID != nil && teamID.String() == r.Body.TeamID.String() ||
-			teamID == nil && r.Body.TeamID == nil {
+		if (teamID == nil && r.Body.TeamID == nil) ||
+			(teamID != nil && r.Body.TeamID != nil && teamID.String() == r.Body.TeamID.String()) {
 			results = append(results, r)
 		}
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -107,7 +107,7 @@ func list(cliCtx *cli.Context) error {
 	}
 
 	// Get operations
-	oRes, err := clients.FetchOperations(ctx, pClient, nil)
+	oRes, err := clients.FetchOperations(ctx, pClient, teamID)
 	if err != nil {
 		return cli.NewExitError("Failed to fetch the list of operations: "+err.Error(), -1)
 	}


### PR DESCRIPTION
Original behaviour is that we would return everything a user had access to when the context was nil, also the operations list was not adhering to the teamID context.

New behaviour:

- `manifold switch` select own account
- `manifold list` display only your own resources and operations
- `manifold switch` select a team
- `manifold list` see only resources and operations for that team