### PR TITLE
Chained E-mail verification into signup process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- Chained e-mail verification step to the end of the signup command
+
+### Fixed
+
+
+### Removed
+
+
 ## [0.5.0] - 2017-08-14
 
 ### Added

--- a/cmd/signup.go
+++ b/cmd/signup.go
@@ -73,5 +73,8 @@ func signup(_ *cli.Context) error {
 	a.Track(ctx, "Logged In", nil)
 
 	fmt.Println("Account created. You are logged in.")
-	return nil
+
+	fmt.Println("A verification code has been sent to your e-mail address.")
+
+	return verifyEmailCode(ctx, cfg, s, "")
 }

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -23,13 +23,13 @@ func init() {
 		ArgsUsage: "[code]",
 		Usage:     "Verify an e-mail address with an e-mail verification code",
 		Category:  "ADMINISTRATIVE",
-		Action:    verifyEmailCode,
+		Action:    verify,
 	}
 
 	cmds = append(cmds, verifyCmd)
 }
 
-func verifyEmailCode(cliCtx *cli.Context) error {
+func verify(cliCtx *cli.Context) error {
 	ctx := context.Background()
 
 	if err := maxOptionalArgsLength(cliCtx, 1); err != nil {
@@ -37,13 +37,6 @@ func verifyEmailCode(cliCtx *cli.Context) error {
 	}
 
 	verificationCode, err := optionalArgCode(cliCtx, 0, "e-mail verification")
-	if err != nil {
-		return err
-	}
-
-	if verificationCode == "" {
-		verificationCode, err = prompts.EmailVerificationCode("")
-	}
 	if err != nil {
 		return err
 	}
@@ -60,6 +53,20 @@ func verifyEmailCode(cliCtx *cli.Context) error {
 
 	if !s.Authenticated() {
 		return errs.ErrMustLogin
+	}
+
+	return verifyEmailCode(ctx, cfg, s, verificationCode)
+}
+
+func verifyEmailCode(ctx context.Context, cfg *config.Config,
+	s session.Session, verificationCode string) error {
+
+	var err error
+	if verificationCode == "" {
+		verificationCode, err = prompts.EmailVerificationCode("")
+	}
+	if err != nil {
+		return err
 	}
 
 	identityClient, err := clients.NewIdentity(cfg)


### PR DESCRIPTION
```
[tim@timtop manifold-cli]$ manifold signup
✔ Name: Tspeed
✔ Email: tim++@manifold.co
✔ Password: ●●●●●●●●●●●
Account created. You are logged in.
A verification code has been sent to your e-mail address.
✔ E-mail Verification Code: 84x9vvn1x071kydd
Thanks! Your e-mail address has been verified.
[tim@timtop manifold-cli]$ manifold verify 84x9vvn1x071kydd
Failed to verify e-mail code: [POST /users/verify][400] postUsersVerifyBadRequest  bad_request: Invalid verification code
```