### PR TITLE
Wrap project delete error responses so they'll be displayed

### DIFF
--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -342,13 +342,13 @@ func deleteProjectCmd(cliCtx *cli.Context) error {
 	if err != nil {
 		switch e := err.(type) {
 		case *operation.PutOperationsIDBadRequest:
-			return e.Payload
+			return cli.NewExitError(e.Payload, -1)
 		case *operation.PutOperationsIDUnauthorized:
-			return e.Payload
+			return cli.NewExitError(e.Payload, -1)
 		case *operation.PutOperationsIDNotFound:
-			return e.Payload
+			return cli.NewExitError(e.Payload, -1)
 		case *operation.PutOperationsIDConflict:
-			return e.Payload
+			return cli.NewExitError(e.Payload, -1)
 		case *operation.PutOperationsIDInternalServerError:
 			return errs.ErrSomethingWentHorriblyWrong
 		default:


### PR DESCRIPTION
If something goes wrong with a delete request, we want to at least show
our bad error messages, instead of nothing at all.