### PR TITLE
Manifold context command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `manifold teams invite` now supports Role selection
 - `manifold teams set-role` can update the role of an existing team member
 - `manifold teams remove` will remove a team member or revoke an invite
+- `manifold context` command to display current account and context
 
 ### Fixed
 - Update success and failure output for `manifold config set`

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/juju/ansiterm"
+	"github.com/urfave/cli"
+
+	"github.com/manifoldco/manifold-cli/color"
+	"github.com/manifoldco/manifold-cli/config"
+	"github.com/manifoldco/manifold-cli/middleware"
+	"github.com/manifoldco/manifold-cli/session"
+)
+
+func init() {
+	versionCmd := cli.Command{
+		Name:     "context",
+		Usage:    "Display current context of this tool",
+		Category: "UTILITY",
+		Flags: append(teamFlags, []cli.Flag{
+			cli.BoolFlag{
+				Name:  "short, s",
+				Usage: "Display only the label of the current context",
+			},
+		}...),
+		Action: middleware.Chain(middleware.LoadDirPrefs, middleware.EnsureSession,
+			middleware.LoadTeamPrefs, contextLookup),
+	}
+
+	cmds = append(cmds, versionCmd)
+}
+
+func contextLookup(cliCtx *cli.Context) error {
+	ctx := context.Background()
+
+	cfg, err := config.Load()
+	if err != nil {
+		return cli.NewExitError("Could not load config: "+err.Error(), -1)
+	}
+
+	teamID, err := validateTeamID(cliCtx)
+	if err != nil {
+		return err
+	}
+
+	var me bool
+	var teamName string
+	var s session.Session
+
+	if teamID != nil {
+		teamName = cfg.TeamName
+		if teamName == "" {
+			teamName = "unknown"
+		}
+	} else {
+		me = true
+	}
+	if !cliCtx.Bool("short") || me {
+		s, err = session.Retrieve(ctx, cfg)
+		if err != nil {
+			return err
+		}
+	}
+
+	switch cliCtx.Bool("short") {
+	case true:
+		if me {
+			fmt.Println(s.User().Body.Email)
+		} else {
+			fmt.Println(teamName)
+		}
+	default:
+		usr := s.User()
+
+		fmt.Println("Use `manifold switch` to change contexts")
+		fmt.Println("")
+		var ctxValue, ctxType string
+		if me {
+			ctxType = "user"
+			ctxValue = fmt.Sprintf("%s (%s)", usr.Body.Name, usr.Body.Email)
+		} else {
+			ctxType = "team"
+			ctxValue = fmt.Sprintf("%s (%s)", cfg.TeamName, cfg.TeamTitle)
+		}
+
+		faint := func(i interface{}) string {
+			return color.Color(ansiterm.Gray, i)
+		}
+
+		fmt.Println(color.Bold("Account"))
+		w := ansiterm.NewTabWriter(os.Stdout, 0, 0, 8, ' ', 0)
+		fmt.Fprintln(w, fmt.Sprintf("%s\t%s", faint("Name"), usr.Body.Name))
+		fmt.Fprintln(w, fmt.Sprintf("%s\t%s", faint("Email"), usr.Body.Email))
+		w.Flush()
+		fmt.Println("")
+		fmt.Println(color.Bold("Context"))
+		w = ansiterm.NewTabWriter(os.Stdout, 0, 0, 8, ' ', 0)
+		fmt.Fprintln(w, fmt.Sprintf("%s\t%s", faint("Type"), ctxType))
+		fmt.Fprintln(w, fmt.Sprintf("%s\t%s", faint("Value"), ctxValue))
+		w.Flush()
+	}
+	return nil
+}

--- a/cmd/switch.go
+++ b/cmd/switch.go
@@ -34,7 +34,7 @@ func init() {
 func switchTeamCmd(cliCtx *cli.Context) error {
 	ctx := context.Background()
 
-	cfg, err := config.Load()
+	cfg, err := config.LoadIgnoreLegacy()
 	if err != nil {
 		return cli.NewExitError(fmt.Sprintf("Could not load configuration: %s", err), -1)
 	}
@@ -107,9 +107,13 @@ func switchTeam(ctx context.Context, cfg *config.Config, team *models.Team) erro
 		return err
 	}
 
-	cfg.Team = ""
+	cfg.TeamID = ""
+	cfg.TeamTitle = ""
+	cfg.TeamName = ""
 	if team != nil {
-		cfg.Team = team.ID.String()
+		cfg.TeamID = team.ID.String()
+		cfg.TeamTitle = string(team.Body.Name)
+		cfg.TeamName = string(team.Body.Label)
 	}
 
 	if err := cfg.Write(); err != nil {
@@ -118,11 +122,11 @@ func switchTeam(ctx context.Context, cfg *config.Config, team *models.Team) erro
 
 	params := map[string]string{}
 	if team != nil {
-		params["team-label"] = string(team.Body.Label)
-		params["team-name"] = string(team.Body.Name)
+		params["team-name"] = cfg.TeamName
+		params["team-title"] = cfg.TeamTitle
 	} else {
-		params["team-label"] = ""
 		params["team-name"] = ""
+		params["team-title"] = ""
 	}
 	a.Track(ctx, "Switched Context", &params)
 


### PR DESCRIPTION
### Proposal
Store the team label and name in config so that it's more readily available.
Add a status command that shows the current context.

### Why?
We have an issue of not surfacing the context enough, so that a user knows which area they are operating in.

1. Having a status command makes it easily viewable
2. Implementing a `--short` flag enables us to expose just the label of the context
3. We can then provide a bash snippet for people to use in their PS1 to have it visible -- ie. ` ~/manifoldco (jeff@manifold.co) $ manifold run node index.js`

### Problems

Our middleware needs to be sped up to make it reasonable to include in someones PS1

![1u0q9byw](https://user-images.githubusercontent.com/474438/30996090-7749c4da-a494-11e7-9791-48dea307dfa6.png)
