### PR TITLE
Fix config unset command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- `config unset` accepts `--team` flag
+- `config unset` fails if no key is passed
+- `config unset` fails with a friendlier message
+
 ## [0.6.0] - 2017-10-03
 
 ### Added

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -104,12 +104,17 @@ func patchConfig(cliCtx *cli.Context, req map[string]*string) error {
 		Body:    req,
 		Context: ctx,
 	}, nil)
+
 	if err != nil {
-		return cli.NewExitError("Error updating config: "+err.Error(), -1)
+		switch e := err.(type) {
+		case *credential.PatchResourcesIDConfigBadRequest:
+			return cli.NewExitError("Could not change config: invalid key.", -1)
+		default:
+			return cli.NewExitError(e, -1)
+		}
 	}
 
 	return nil
-
 }
 
 func configSetCmd(cliCtx *cli.Context) error {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -125,8 +125,14 @@ func configSetCmd(cliCtx *cli.Context) error {
 }
 
 func configUnsetCmd(cliCtx *cli.Context) error {
+	args := cliCtx.Args()
+
+	if len(args) == 0 {
+		return cli.NewExitError("At least one key must be present", -1)
+	}
+
 	req := make(map[string]*string)
-	for _, arg := range cliCtx.Args() {
+	for _, arg := range args {
 		req[arg] = nil
 	}
 	return patchConfig(cliCtx, req)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -39,9 +39,9 @@ func init() {
 				Name:      "unset",
 				ArgsUsage: "<key...>",
 				Usage:     "Unset one or more config values on a custom resource",
-				Flags: []cli.Flag{
+				Flags: append(teamFlags, []cli.Flag{
 					resourceFlag(),
-				},
+				}...),
 				Action: middleware.Chain(middleware.EnsureSession, middleware.LoadTeamPrefs,
 					configUnsetCmd),
 			},


### PR DESCRIPTION
Changes:

- `config unset` accepts `--team` flag
- `config unset` fails if no key is passed
- `config unset` fails with a friendlier message

Closes: https://github.com/manifoldco/engineering/issues/3061
Closes: https://github.com/manifoldco/engineering/issues/3062