### PR TITLE
Experimental install.sh script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `services providers` to list providers
 - `services products` to list products
 - `services plans` to list plans
+- install.sh script to download latest release
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PKG=github.com/manifoldco/manifold-cli
 STRIPE_PKEY=${STRIPE_PUBLISHABLE_KEY}
 GO_BUILD=CGO_ENABLED=0 go build -i --ldflags="-w -X $(PKG)/config.Version=$(VERSION) -X $(PKG)/config.StripePublishableKey=$(STRIPE_PKEY)"
 
-PROMULGATE_VERSION=0.0.6
+PROMULGATE_VERSION=0.0.7
 
 rwildcard=$(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) \
     $(filter $(subst *,%,$2),$d))

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ Manage your cloud services like a developer.
 
 ## Installation
 
+#### Install script
+
+To install or update manifold, you can use the install script using cURL:
+
+```
+curl -o- https://raw.githubusercontent.com/manifoldco/manifold-co/master/install.sh | sh
+```
+
 #### Homebrew (OS X)
 
 Homebrew can be installed via [brew.sh](http://brew.sh)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Manage your cloud services like a developer.
 
 ## Installation
 
-#### Install script
+### Install script
 
 To install or update manifold, you can use the install script using cURL:
 
@@ -22,7 +22,11 @@ To install or update manifold, you can use the install script using cURL:
 curl -o- https://raw.githubusercontent.com/manifoldco/manifold-co/master/install.sh | sh
 ```
 
-#### Homebrew (OS X)
+You can customize the install directory, profile, and version using the
+`MANIFOLD_DIR`, `PROFILE` and `MANIFOLD_VERSION` variables. Eg: `curl ... |
+MANIFOLD_DIR=/usr/local sh` for a global install.
+
+### Homebrew (OS X)
 
 Homebrew can be installed via [brew.sh](http://brew.sh)
 
@@ -30,7 +34,7 @@ Homebrew can be installed via [brew.sh](http://brew.sh)
 $ brew install manifoldco/brew/manifold-cli
 ```
 
-#### Zip Archives (OS X, Linux, Windows)
+### Zip Archives (OS X, Linux, Windows)
 
 Bare zip archives per release version are available on https://releases.manifold.co
 

--- a/install.sh
+++ b/install.sh
@@ -89,8 +89,8 @@
     error_exit "32 bits architecture is not supported"
   fi
 
-  if ! is_installed unzip; then
-    error_exit "You must have 'unzip' installed before proceeding."
+  if ! is_installed tar; then
+    error_exit "You must have 'tar' installed before proceeding."
   fi
 
   OS=`uname | tr '[:upper:]' '[:lower:]'`
@@ -125,7 +125,7 @@
   curl -sS --compressed -L -q $ARTIFACT_URL --output $FILENAME
   success_msg "Version ($MANIFOLD_VERSION) downloaded"
 
-  unzip -o $FILENAME 1> /dev/null
+  tar xvf $FILENAME 1> /dev/null
 
   rm $FILENAME
 

--- a/install.sh
+++ b/install.sh
@@ -89,14 +89,14 @@
     error_exit "32 bits architecture is not supported"
   fi
 
-  if ! is_installed tar; then
-    error_exit "You must have 'tar' installed before proceeding."
-  fi
-
   OS=`uname | tr '[:upper:]' '[:lower:]'`
 
   if [ "$OS" != "linux" ] && [ "$OS" != "darwin" ]; then
     error_exit "Operational System $OS not supported."
+  fi
+
+  if ! is_installed tar; then
+    error_exit "You must have 'tar' installed before proceeding."
   fi
 
   if is_installed manifold; then
@@ -133,12 +133,12 @@
 
   if is_installed manifold; then
     PREVIOUS_INSTALLATION=`which manifold`
-    if [ "$PREVIOUS_INSTALLATION" != "$MANIFOLD_DIR/manifold" ]; then
-      warning_msg "Another executable detected: `type manifold`"
-      success_msg "Binary installed at $MANIFOLD_DIR"
-      warning_msg "To manually run this current installation: .$MANIFOLD_DIR/manifold"
-    else
+    if [ "$PREVIOUS_INSTALLATION" == "$MANIFOLD_DIR/manifold" ]; then
       success_msg "Binary updated at $MANIFOLD_DIR"
+    else
+      success_msg "Binary installed at $MANIFOLD_DIR"
+      warning_msg "Another executable detected: `type manifold`"
+      warning_msg "To manually run this current installation: .$MANIFOLD_DIR/manifold"
     fi
   else
     success_msg "Binary installed at $MANIFOLD_DIR"

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,10 @@
 
 { # this ensures the entire script is downloaded #
 
+  is_installed() {
+    type "$1" > /dev/null 2>&1
+  }
+
   error_exit() {
     tput sgr0
     tput setaf 1
@@ -85,6 +89,10 @@
     error_exit "32 bits architecture is not supported"
   fi
 
+  if is_installed manifold; then
+    warning_msg "Previous installation detected: v`manifold -v`"
+  fi
+
   OS=`uname | tr '[:upper:]' '[:lower:]'`
 
   REPO="https://github.com/manifoldco/manifold-cli"
@@ -109,11 +117,23 @@
   success_msg "Latest version ($LATEST_VERSION) downloaded"
 
   #unzip -o $FILENAME
-  success_msg "Binary installed at $DESTINATION_DIR"
-
-  #rm $FILENAME
 
   popd > /dev/null
+
+  if is_installed manifold; then
+    PREVIOUS_INSTALLATION=`which manifold`
+    if [ "$PREVIOUS_INSTALLATION" != "$DESTINATION_DIR/manifold" ]; then
+      warning_msg "Another executable detected: `type manifold`"
+      success_msg "Binary installed at $DESTINATION_DIR"
+      warning_msg "To manually run this current installation: .$DESTINATION_DIR/manifold"
+    else
+      success_msg "Binary updated at $DESTINATION_DIR"
+    fi
+  else
+    success_msg "Binary installed at $DESTINATION_DIR"
+  fi
+
+  #rm $FILENAME
 
   PROFILE=`detect_profile`
 

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# Inspired by: github.com/moovweb/gvm
+# Inspired by:
+# - https://github.com/creationix/nvm
+# - https://github.com/moovweb/gvm
+# - https://blog.markvincze.com/download-artifacts-from-a-latest-github-release-in-sh-and-powershell/
 
 { # this ensures the entire script is downloaded #
 
@@ -11,6 +14,53 @@
     exit 1
   }
 
+  try_profile() {
+    if [ -z "${1-}" ] || [ ! -f "${1}" ]; then
+      return 1
+    fi
+    echo "${1}"
+  }
+
+  #
+  # Detect profile file if not specified as environment variable
+  # (eg: PROFILE=~/.myprofile)
+  # The echo'ed path is guaranteed to be an existing file
+  # Otherwise, an empty string is returned
+  #
+  detect_profile() {
+    if [ -n "${PROFILE}" ] && [ -f "${PROFILE}" ]; then
+      echo "${PROFILE}"
+      return
+    fi
+
+    local DETECTED_PROFILE
+    DETECTED_PROFILE=''
+    local SHELLTYPE
+    SHELLTYPE="$(basename "/$SHELL")"
+
+    if [ "$SHELLTYPE" = "bash" ]; then
+      if [ -f "$HOME/.bashrc" ]; then
+        DETECTED_PROFILE="$HOME/.bashrc"
+      elif [ -f "$HOME/.bash_profile" ]; then
+        DETECTED_PROFILE="$HOME/.bash_profile"
+      fi
+    elif [ "$SHELLTYPE" = "zsh" ]; then
+      DETECTED_PROFILE="$HOME/.zshrc"
+    fi
+
+    if [ -z "$DETECTED_PROFILE" ]; then
+      for EACH_PROFILE in ".profile" ".bashrc" ".bash_profile" ".zshrc"
+      do
+        if DETECTED_PROFILE="$(try_profile "${HOME}/${EACH_PROFILE}")"; then
+          break
+        fi
+      done
+    fi
+
+    if [ ! -z "$DETECTED_PROFILE" ]; then
+      echo "$DETECTED_PROFILE"
+    fi
+  }
 
   MACHINE_TYPE=`uname -m`
   if [ ${MACHINE_TYPE} != 'x86_64' ]; then
@@ -26,10 +76,47 @@
   # The releases are returned in the format {"id":3622206,"tag_name":"hello-1.0.0.11",...}, we have to extract the tag_name.
   LATEST_VERSION=$(echo $LATEST_RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
 
+  # Create filename accordingly to manifoldco/promulgate structure
   FILENAME="manifold-cli_${LATEST_VERSION:1}_${OS}_amd64.zip"
+
   ARTIFACT_URL="${REPO}/releases/download/${LATEST_VERSION}/${FILENAME}"
 
+  DESTINATION_DIR="${HOME}/.manifold/bin"
+
+  echo "Creating directory at $DESTINATION_DIR"
+  mkdir -p $DESTINATION_DIR
+
+  pushd $DESTINATION_DIR > /dev/null
+
   echo "Downloading latest release (${LATEST_VERSION}) for manifold-cli"
+
   curl --compressed -L -q $ARTIFACT_URL --output $FILENAME
 
+  echo "Extracting file"
+  unzip $FILENAME
+
+  rm $FILENAME
+
+  popd > /dev/null
+
+  PROFILE=`detect_profile`
+
+  PATH_CHANGE="export PATH=\"\$PATH:$DESTINATION_DIR\""
+
+  if [ "$PROFILE" == "" ]; then
+    echo "Unable to locate profile settings file(Something like $HOME/.bashrc or $HOME/.bash_profile)"
+    echo
+    echo "You will have to manually add the following line:"
+    echo
+    echo "  $PATH_CHANGE"
+    echo
+  else
+    echo $PATH_CHANGE >> $PROFILE
+    echo "Your $PROFILE has changed to include $DESTINATION_DIR into your PATH"
+  fi
+
+  echo
+  echo "All done!"
+  echo "Please restart or resource your terminal session."
+  echo "Happy manifold use! :)"
 }

--- a/install.sh
+++ b/install.sh
@@ -93,7 +93,7 @@
   curl --compressed -L -q $ARTIFACT_URL --output $FILENAME
 
   echo "Extracting file"
-  unzip $FILENAME
+  unzip -o $FILENAME
 
   rm $FILENAME
 

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Inspired by:
 # - https://github.com/creationix/nvm
 # - https://github.com/moovweb/gvm

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Inspired by: github.com/moovweb/gvm
+
+{ # this ensures the entire script is downloaded #
+
+  display_error() {
+    tput sgr0
+    tput setaf 1
+    echo "ERROR: $1"
+    tput sgr0
+    exit 1
+  }
+
+
+  MACHINE_TYPE=`uname -m`
+  if [ ${MACHINE_TYPE} != 'x86_64' ]; then
+    display_error "32 bits architecture is not supported"
+  fi
+
+  OS=`uname | tr '[:upper:]' '[:lower:]'`
+
+  REPO="https://github.com/manifoldco/manifold-cli"
+
+  LATEST_RELEASE=$(curl -L -s -H 'Accept: application/json' ${REPO}/releases/latest)
+
+  # The releases are returned in the format {"id":3622206,"tag_name":"hello-1.0.0.11",...}, we have to extract the tag_name.
+  LATEST_VERSION=$(echo $LATEST_RELEASE | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
+
+  FILENAME="manifold-cli_${LATEST_VERSION:1}_${OS}_amd64.zip"
+  ARTIFACT_URL="${REPO}/releases/download/${LATEST_VERSION}/${FILENAME}"
+
+  echo "Downloading latest release (${LATEST_VERSION}) for manifold-cli"
+  curl --compressed -L -q $ARTIFACT_URL --output $FILENAME
+
+}


### PR DESCRIPTION
Allow users to download and install a binary version of manifold from the cmdline.

Closes: https://github.com/manifoldco/engineering/issues/3100