### PR TITLE
Add manifold teams remove command to revoke invites or remove members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `manifold teams members` can list members of a team
 - `manifold teams invite` now supports Role selection
 - `manifold teams set-role` can update the role of an existing team member
+- `manifold teams remove` will remove a team member or revoke an invite
 
 ### Fixed
 


### PR DESCRIPTION
```
$ manifold teams invite jeff+test@manifold.co
✔ Select Team: awesomesauce (awesomesauce)
✔ Name: Jeff Andersen
✔ Select Role: read
An invite has been sent to Jeff Andersen <jeff+test@manifold.co>
```
```
$ manifold teams members
1 members and 1 invites
Use `manifold switch` to change to a different team

Name                 Email                        Role         Status
jeff                 jeff@manifold.co             admin        active
Jeff Andersen        jeff+test@manifold.co        read         pending
```
```
$ manifold teams remove jeff+test@manifold.co
Invite to Jeff Andersen <jeff+test@manifold.co> has been revoked
```