### PR TITLE
Naming convention changes: Names are Titles, Labels are Names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Prevent error during resize attempt of custom resource
 - Amend output for NewUsageError to pull from framework help
 - `teams create` can be used non-interatively
+- Terminology has changed: Name becomes Title, Label becomes Name
 
 ## [0.7.1] - 2017-10-12
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -64,7 +64,7 @@ func patchConfig(cliCtx *cli.Context, req map[string]*string) error {
 		}
 	}
 
-	label, err := requiredLabel(cliCtx, "resource")
+	name, err := requiredName(cliCtx, "resource")
 	if err != nil {
 		return err
 	}
@@ -87,14 +87,14 @@ func patchConfig(cliCtx *cli.Context, req map[string]*string) error {
 	// XXX just get a single resource
 	var resource *models.Resource
 	for _, r := range resources {
-		if string(r.Body.Label) == label {
+		if string(r.Body.Label) == name {
 			resource = r
 			break
 		}
 	}
 
 	if resource == nil {
-		return cli.NewExitError("No resource found with that label", -1)
+		return cli.NewExitError("No resource found with that name", -1)
 	}
 	if *resource.Body.Source != "custom" {
 		return cli.NewExitError("Config can only be set on custom resources", -1)

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -27,7 +27,7 @@ import (
 func init() {
 	deleteCmd := cli.Command{
 		Name:      "delete",
-		ArgsUsage: "[name]",
+		ArgsUsage: "[resource-name]",
 		Usage:     "Delete a resource",
 		Category:  "RESOURCES",
 		Action:    middleware.Chain(middleware.EnsureSession, middleware.LoadTeamPrefs, deleteCmd),
@@ -49,7 +49,7 @@ func deleteCmd(cliCtx *cli.Context) error {
 		return err
 	}
 
-	resourceLabel, err := optionalArgLabel(cliCtx, 0, "resource")
+	resourceName, err := optionalArgName(cliCtx, 0, "resource")
 	if err != nil {
 		return err
 	}
@@ -59,7 +59,7 @@ func deleteCmd(cliCtx *cli.Context) error {
 		return err
 	}
 
-	projectLabel, err := validateLabel(cliCtx, "project")
+	projectName, err := validateName(cliCtx, "project")
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func deleteCmd(cliCtx *cli.Context) error {
 		return err
 	}
 
-	resources, err := clients.FetchResources(ctx, client.Marketplace, teamID, projectLabel)
+	resources, err := clients.FetchResources(ctx, client.Marketplace, teamID, projectName)
 	if err != nil {
 		return cli.NewExitError(
 			fmt.Sprintf("Failed to fetch the list of provisioned resources: %s", err), -1)
@@ -96,14 +96,14 @@ func deleteCmd(cliCtx *cli.Context) error {
 	}
 
 	var resource *mModels.Resource
-	if resourceLabel != "" {
-		resource, err = pickResourcesByLabel(resources, resourceLabel)
+	if resourceName != "" {
+		resource, err = pickResourcesByName(resources, resourceName)
 		if err != nil {
 			return cli.NewExitError(
-				fmt.Sprintf("Failed to find resource \"%s\": %s", resourceLabel, err), -1)
+				fmt.Sprintf("Failed to find resource \"%s\": %s", resourceName, err), -1)
 		}
 	} else {
-		idx, _, err := prompts.SelectResource(resources, projects, resourceLabel)
+		idx, _, err := prompts.SelectResource(resources, projects, resourceName)
 		if err != nil {
 			return prompts.HandleSelectError(err, "Could not select Resource")
 		}

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -45,7 +45,7 @@ func init() {
 func export(cliCtx *cli.Context) error {
 	ctx := context.Background()
 
-	projectLabel, err := validateLabel(cliCtx, "project")
+	projectName, err := validateName(cliCtx, "project")
 	if err != nil {
 		return err
 	}
@@ -66,13 +66,13 @@ func export(cliCtx *cli.Context) error {
 	}
 
 	prompts.SpinStart("Fetching Resources")
-	resources, err := clients.FetchResources(ctx, client.Marketplace, teamID, projectLabel)
+	resources, err := clients.FetchResources(ctx, client.Marketplace, teamID, projectName)
 	prompts.SpinStop()
 	if err != nil {
 		return cli.NewExitError("Could not retrieve resources: "+err.Error(), -1)
 	}
 
-	if projectLabel == "" {
+	if projectName == "" {
 		resources = filterResourcesWithoutProjects(resources)
 	}
 
@@ -88,8 +88,8 @@ func export(cliCtx *cli.Context) error {
 	params := map[string]string{
 		format: format,
 	}
-	if projectLabel != "" {
-		params["project"] = projectLabel
+	if projectName != "" {
+		params["project"] = projectName
 	}
 
 	client.Analytics.Track(ctx, "Exported Credentials", &params)

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -12,12 +12,12 @@ func formatFlag(defaultValue, description string) cli.Flag {
 	return placeholder.New("format, f", "FORMAT", description, defaultValue, "MANIFOLD_FORMAT", false)
 }
 
-func nameFlag() cli.Flag {
+func titleFlag() cli.Flag {
 	return cli.StringFlag{
-		Name:   "name, n",
-		Usage:  "Specify a name for a resource",
+		Name:   "title, t",
+		Usage:  "Specify a title to be used",
 		Value:  "",
-		EnvVar: "MANIFOLD_NAME",
+		EnvVar: "MANIFOLD_TITLE",
 	}
 }
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -37,7 +37,7 @@ func init() {
 
 func initDir(cliCtx *cli.Context) error {
 	ctx := context.Background()
-	projectLabel := cliCtx.String("project")
+	projectName := cliCtx.String("project")
 
 	teamID, err := validateTeamID(cliCtx)
 	if err != nil {
@@ -66,22 +66,22 @@ func initDir(cliCtx *cli.Context) error {
 		return errs.ErrNoProjects
 	}
 
-	pIdx, _, err := prompts.SelectProject(ps, projectLabel, true)
+	pIdx, _, err := prompts.SelectProject(ps, projectName, true)
 	if err != nil {
 		return prompts.HandleSelectError(err, "Could not select project.")
 	}
 	if pIdx == -1 {
-		projectLabel = ""
+		projectName = ""
 	} else {
-		projectLabel = string(ps[pIdx].Body.Label)
+		projectName = string(ps[pIdx].Body.Label)
 	}
 
 	cwd, err := os.Getwd()
 	if err != nil {
 		return err
 	}
-	oldLabel := mYaml.Project
-	mYaml.Project = projectLabel
+	oldName := mYaml.Project
+	mYaml.Project = projectName
 	mYaml.Path = filepath.Join(cwd, config.YamlFilename)
 
 	err = mYaml.Save()
@@ -93,11 +93,11 @@ func initDir(cliCtx *cli.Context) error {
 
 	if mYaml.Project == "" {
 		fmt.Println("\nThis directory and its subdirectories have been unlinked from:")
-		fmt.Fprintf(w, "Project:\t%s\n", oldLabel)
+		fmt.Fprintf(w, "Project:\t%s\n", oldName)
 	} else {
 		// Display the output
 		fmt.Println("\nThis directory and its subdirectories have been linked to:")
-		fmt.Fprintf(w, "Project:\t%s\n", projectLabel)
+		fmt.Fprintf(w, "Project:\t%s\n", projectName)
 	}
 
 	return w.Flush()

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -51,7 +51,7 @@ func init() {
 func list(cliCtx *cli.Context) error {
 	ctx := context.Background()
 
-	projectLabel, err := validateLabel(cliCtx, "project")
+	projectName, err := validateName(cliCtx, "project")
 	if err != nil {
 		return err
 	}
@@ -73,7 +73,7 @@ func list(cliCtx *cli.Context) error {
 	}
 
 	// Get resources
-	res, err := clients.FetchResources(ctx, client.Marketplace, teamID, projectLabel)
+	res, err := clients.FetchResources(ctx, client.Marketplace, teamID, projectName)
 	if err != nil {
 		return cli.NewExitError("Failed to fetch the list of provisioned "+
 			"resources: "+err.Error(), -1)
@@ -93,7 +93,7 @@ func list(cliCtx *cli.Context) error {
 	}
 
 	fmt.Printf("%d resources in %d projects\n", list.totalResources, list.totalProjects)
-	fmt.Println("Use `manifold view [label]` to display resource details")
+	fmt.Println("Use `manifold view [resource-name]` to display resource details")
 
 	w := ansiterm.NewTabWriter(os.Stdout, 0, 0, 8, ' ', 0)
 
@@ -112,7 +112,7 @@ func list(cliCtx *cli.Context) error {
 		fmt.Fprintf(w, "\n")
 
 		w.SetForeground(ansiterm.Gray)
-		fmt.Fprintln(w, "Label\tType\tStatus")
+		fmt.Fprintln(w, "Name\tTitle\tType\tStatus")
 		w.Reset()
 
 		for _, resource := range group.resources {
@@ -139,7 +139,7 @@ func list(cliCtx *cli.Context) error {
 				status = "Ready"
 			}
 
-			fmt.Fprintf(w, "%s\t%s\t%s\n", resource.Body.Label, rType, status)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", resource.Body.Label, resource.Body.Name, rType, status)
 		}
 	}
 
@@ -261,7 +261,7 @@ func groupResources(ctx context.Context, client *api.API, resources []*models.Re
 		m[key] = list
 	}
 
-	// Assemble groups into a single list, sorting resources by label
+	// Assemble groups into a single list, sorting resources by name
 	var groups []resourceGroup
 	for k, v := range m {
 		sort.Slice(v, func(i, j int) bool {
@@ -271,7 +271,7 @@ func groupResources(ctx context.Context, client *api.API, resources []*models.Re
 		var owner string
 		var project string
 
-		// Find the correct owner, either a team label or the user email
+		// Find the correct owner, either a team name or the user email
 		if !k.user.IsEmpty() {
 			owner = email
 		} else {
@@ -282,7 +282,7 @@ func groupResources(ctx context.Context, client *api.API, resources []*models.Re
 			}
 		}
 
-		// Find the project label if any
+		// Find the project name if any
 		if !k.project.IsEmpty() {
 			list.totalProjects++
 			for _, p := range projects {
@@ -328,11 +328,11 @@ func userEmail(ctx context.Context) (string, error) {
 		return "", cli.NewExitError("Could not retrieve session: "+err.Error(), -1)
 	}
 
-	label := s.LabelInfo()
+	userDetail := s.LabelInfo()
 
-	if label == nil && len(*label) < 2 {
+	if userDetail == nil && len(*userDetail) < 2 {
 		return "", cli.NewExitError("Could not retrieve user email", -1)
 	}
 
-	return (*label)[1], nil
+	return (*userDetail)[1], nil
 }

--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -39,7 +39,7 @@ func init() {
 				Name:      "create",
 				Usage:     "Create a new project",
 				Flags:     teamFlags,
-				ArgsUsage: "[name]",
+				ArgsUsage: "[project-name]",
 				Action: middleware.Chain(middleware.EnsureSession,
 					middleware.LoadTeamPrefs, createProjectCmd),
 			},
@@ -57,9 +57,9 @@ func init() {
 				Name:  "update",
 				Usage: "Update an existing project",
 				Flags: append(teamFlags, []cli.Flag{
-					nameFlag(), descriptionFlag(),
+					titleFlag(), descriptionFlag(),
 				}...),
-				ArgsUsage: "[label]",
+				ArgsUsage: "[project-name]",
 				Action: middleware.Chain(middleware.EnsureSession, middleware.LoadTeamPrefs,
 					updateProjectCmd),
 			},
@@ -67,7 +67,7 @@ func init() {
 				Name:      "delete",
 				Usage:     "Delete a project",
 				Flags:     teamFlags,
-				ArgsUsage: "[name]",
+				ArgsUsage: "[project-name]",
 				Action: middleware.Chain(middleware.EnsureSession,
 					middleware.LoadTeamPrefs, deleteProjectCmd),
 			},
@@ -75,7 +75,7 @@ func init() {
 
 				Name:      "add",
 				Usage:     "Adds or moves a resource to a project",
-				ArgsUsage: "[project-label] [resource-label]",
+				ArgsUsage: "[project-name] [resource-name]",
 				Flags: append(teamFlags, []cli.Flag{
 					skipFlag(),
 				}...),
@@ -120,15 +120,15 @@ func createProjectCmd(cliCtx *cli.Context) error {
 	}
 
 	autoSelect := projectName != ""
-	projectName, err = prompts.ProjectName(projectName, autoSelect)
+	projectTitle, err := prompts.ProjectTitle(projectName, autoSelect)
 	if err != nil {
 		return prompts.HandleSelectError(err, "Failed to name project")
 	}
 
 	params := projectClient.NewPostProjectsParamsWithContext(ctx)
 	body := &mModels.CreateProjectBody{
-		Name:  manifold.Name(projectName),
-		Label: generateLabel(projectName),
+		Name:  manifold.Name(projectTitle),
+		Label: generateName(projectName),
 	}
 
 	if teamID == nil {
@@ -150,7 +150,7 @@ func createProjectCmd(cliCtx *cli.Context) error {
 	}
 
 	spin.Stop()
-	fmt.Printf("Your project '%s' has been created\n", projectName)
+	fmt.Printf("Your project '%s' has been created\n", projectTitle)
 	return nil
 }
 
@@ -203,12 +203,12 @@ func updateProjectCmd(cliCtx *cli.Context) error {
 		return err
 	}
 
-	projectLabel, err := optionalArgLabel(cliCtx, 0, "project")
+	projectName, err := optionalArgName(cliCtx, 0, "project")
 	if err != nil {
 		return err
 	}
 
-	newProjectName, err := validateName(cliCtx, "name", "project")
+	newProjectTitle, err := validateTitle(cliCtx, "title", "project")
 	if err != nil {
 		return err
 	}
@@ -220,13 +220,13 @@ func updateProjectCmd(cliCtx *cli.Context) error {
 		return err
 	}
 
-	p, err := selectProject(ctx, projectLabel, teamID, client.Marketplace)
+	p, err := selectProject(ctx, projectName, teamID, client.Marketplace)
 	if err != nil {
 		return err
 	}
 
-	autoSelectName := newProjectName != ""
-	newProjectName, err = prompts.ProjectName(newProjectName, autoSelectName)
+	autoSelectTitle := newProjectTitle != ""
+	newProjectTitle, err = prompts.ProjectTitle(newProjectTitle, autoSelectTitle)
 	if err != nil {
 		return prompts.HandleSelectError(err, "Could not select project")
 	}
@@ -239,8 +239,8 @@ func updateProjectCmd(cliCtx *cli.Context) error {
 
 	params := projectClient.NewPatchProjectsIDParamsWithContext(ctx)
 	body := &mModels.PublicUpdateProjectBody{
-		Name:  manifold.Name(newProjectName),
-		Label: generateLabel(newProjectName),
+		Name:  manifold.Name(newProjectTitle),
+		Label: generateName(newProjectTitle),
 	}
 
 	if projectDescription != "" {
@@ -261,7 +261,7 @@ func updateProjectCmd(cliCtx *cli.Context) error {
 	}
 
 	spin.Stop()
-	fmt.Printf("\nYour project \"%s\" has been updated\n", newProjectName)
+	fmt.Printf("\nYour project \"%s\" has been updated\n", newProjectTitle)
 	return nil
 }
 
@@ -282,7 +282,7 @@ func deleteProjectCmd(cliCtx *cli.Context) error {
 		return err
 	}
 
-	projectLabel, err := optionalArgName(cliCtx, 0, "project")
+	projectName, err := optionalArgName(cliCtx, 0, "project")
 	if err != nil {
 		return err
 	}
@@ -292,7 +292,7 @@ func deleteProjectCmd(cliCtx *cli.Context) error {
 		return err
 	}
 
-	p, err := selectProject(ctx, projectLabel, teamID, client.Marketplace)
+	p, err := selectProject(ctx, projectName, teamID, client.Marketplace)
 	if err != nil {
 		return err
 	}
@@ -363,12 +363,12 @@ func addProjectCmd(cliCtx *cli.Context) error {
 		return err
 	}
 
-	projectLabel, err := optionalArgLabel(cliCtx, 0, "project")
+	projectName, err := optionalArgName(cliCtx, 0, "project")
 	if err != nil {
 		return err
 	}
 
-	resourceLabel, err := optionalArgLabel(cliCtx, 1, "resource")
+	resourceName, err := optionalArgName(cliCtx, 1, "resource")
 	if err != nil {
 		return err
 	}
@@ -395,7 +395,7 @@ func addProjectCmd(cliCtx *cli.Context) error {
 		return cli.NewExitError(fmt.Sprintf("Failed to fetch projects list: %s", err), -1)
 	}
 
-	p, err := selectProject(ctx, projectLabel, teamID, client.Marketplace)
+	p, err := selectProject(ctx, projectName, teamID, client.Marketplace)
 	if err != nil {
 		return err
 	}
@@ -407,7 +407,7 @@ func addProjectCmd(cliCtx *cli.Context) error {
 	if len(res) == 0 {
 		return errs.ErrNoResources
 	}
-	resourceIdx, _, err := prompts.SelectResource(res, ps, resourceLabel)
+	resourceIdx, _, err := prompts.SelectResource(res, ps, resourceName)
 	if err != nil {
 		return prompts.HandleSelectError(err, "Could not select Resource")
 	}
@@ -443,7 +443,7 @@ func removeProjectCmd(cliCtx *cli.Context) error {
 		return err
 	}
 
-	resourceLabel, err := optionalArgLabel(cliCtx, 0, "resource")
+	resourceName, err := optionalArgName(cliCtx, 0, "resource")
 	if err != nil {
 		return err
 	}
@@ -488,7 +488,7 @@ func removeProjectCmd(cliCtx *cli.Context) error {
 		return cli.NewExitError(
 			fmt.Sprintf("Failed to fetch list of projects: %s", err), -1)
 	}
-	idx, _, err := prompts.SelectResource(filtered, projects, resourceLabel)
+	idx, _, err := prompts.SelectResource(filtered, projects, resourceName)
 	if err != nil {
 		return prompts.HandleSelectError(err, "Could not select Resource")
 	}
@@ -634,7 +634,7 @@ func updateResourceProject(ctx context.Context, uid, tid *manifold.ID, r *mModel
 }
 
 // selectProject prompts a user to select a project (if selects the one provided automatically)
-func selectProject(ctx context.Context, projectLabel string, teamID *manifold.ID, marketplaceClient *mClient.Marketplace) (*mModels.Project, error) {
+func selectProject(ctx context.Context, projectName string, teamID *manifold.ID, marketplaceClient *mClient.Marketplace) (*mModels.Project, error) {
 	projects, err := clients.FetchProjects(ctx, marketplaceClient, teamID)
 	if err != nil {
 		return nil, cli.NewExitError(fmt.Sprintf("Failed to fetch list of projects: %s", err), -1)
@@ -644,7 +644,7 @@ func selectProject(ctx context.Context, projectLabel string, teamID *manifold.ID
 		return nil, errs.ErrNoProjects
 	}
 
-	idx, _, err := prompts.SelectProject(projects, projectLabel, false)
+	idx, _, err := prompts.SelectProject(projects, projectName, false)
 	if err != nil {
 		return nil, prompts.HandleSelectError(err, "Could not select project")
 	}
@@ -653,8 +653,8 @@ func selectProject(ctx context.Context, projectLabel string, teamID *manifold.ID
 	return p, nil
 }
 
-// generateLabel makes a name lowercase and replace spaces with dashes
-func generateLabel(name string) manifold.Label {
-	label := strings.Replace(strings.ToLower(name), " ", "-", -1)
-	return manifold.Label(label)
+// generateName makes a title lowercase and replace spaces with dashes
+func generateName(title string) manifold.Label {
+	name := strings.Replace(strings.ToLower(title), " ", "-", -1)
+	return manifold.Label(name)
 }

--- a/cmd/resize.go
+++ b/cmd/resize.go
@@ -25,7 +25,7 @@ import (
 func init() {
 	resizeCmd := cli.Command{
 		Name:      "resize",
-		ArgsUsage: "[label]",
+		ArgsUsage: "[resource-name]",
 		Usage:     "Resize a resource",
 		Category:  "RESOURCES",
 		Action: middleware.Chain(middleware.EnsureSession, middleware.LoadDirPrefs, middleware.LoadTeamPrefs,
@@ -47,7 +47,7 @@ func resizeResourceCmd(cliCtx *cli.Context) error {
 		return err
 	}
 
-	label, err := optionalArgLabel(cliCtx, 0, "resource")
+	name, err := optionalArgName(cliCtx, 0, "resource")
 	if err != nil {
 		return err
 	}
@@ -63,7 +63,7 @@ func resizeResourceCmd(cliCtx *cli.Context) error {
 	}
 
 	dontWait := cliCtx.Bool("no-wait")
-	planLabel := cliCtx.String("plan")
+	planName := cliCtx.String("plan")
 
 	client, err := api.New(api.Catalog, api.Marketplace, api.Provisioning)
 	if err != nil {
@@ -87,7 +87,7 @@ func resizeResourceCmd(cliCtx *cli.Context) error {
 	if err != nil {
 		return cli.NewExitError(fmt.Sprintf("Could not load projects: %s", err), -1)
 	}
-	rIdx, _, err := prompts.SelectResource(res, projects, label)
+	rIdx, _, err := prompts.SelectResource(res, projects, name)
 	if err != nil {
 		return prompts.HandleSelectError(err, "Could not select resource")
 	}
@@ -102,7 +102,7 @@ func resizeResourceCmd(cliCtx *cli.Context) error {
 		return errs.ErrNoPlans
 	}
 
-	pIdx, _, err := prompts.SelectPlan(plans, planLabel, false)
+	pIdx, _, err := prompts.SelectPlan(plans, planName, false)
 	if err != nil {
 		return prompts.HandleSelectError(err, "Could not select Plan")
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -43,7 +43,7 @@ func run(cliCtx *cli.Context) error {
 		args = strings.Split(args[0], " ")
 	}
 
-	projectLabel, err := validateName(cliCtx, "project")
+	projectName, err := validateName(cliCtx, "project")
 	if err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ func run(cliCtx *cli.Context) error {
 		return err
 	}
 
-	rs, err := clients.FetchResources(ctx, client.Marketplace, teamID, projectLabel)
+	rs, err := clients.FetchResources(ctx, client.Marketplace, teamID, projectName)
 	if err != nil {
 		return cli.NewExitError("Could not retrieve resources: "+err.Error(), -1)
 	}
@@ -74,8 +74,8 @@ func run(cliCtx *cli.Context) error {
 	}
 
 	params := map[string]string{}
-	if projectLabel != "" {
-		params["project"] = projectLabel
+	if projectName != "" {
+		params["project"] = projectName
 	}
 
 	client.Analytics.Track(ctx, "Project Run", &params)

--- a/cmd/sso.go
+++ b/cmd/sso.go
@@ -21,7 +21,7 @@ import (
 func init() {
 	ssoCmd := cli.Command{
 		Name:      "sso",
-		ArgsUsage: "[label]",
+		ArgsUsage: "[resource-name]",
 		Usage:     "Get an SSO link for a resource",
 		Category:  "RESOURCES",
 		Action: middleware.Chain(middleware.EnsureSession, middleware.LoadDirPrefs, middleware.LoadTeamPrefs,
@@ -42,7 +42,7 @@ func ssoCmd(cliCtx *cli.Context) error {
 		return err
 	}
 
-	label, err := optionalArgLabel(cliCtx, 0, "resource")
+	name, err := optionalArgName(cliCtx, 0, "resource")
 	if err != nil {
 		return err
 	}
@@ -53,7 +53,7 @@ func ssoCmd(cliCtx *cli.Context) error {
 	}
 
 	open := cliCtx.Bool("open")
-	project, err := validateLabel(cliCtx, "project")
+	project, err := validateName(cliCtx, "project")
 	if err != nil {
 		return err
 	}
@@ -76,7 +76,7 @@ func ssoCmd(cliCtx *cli.Context) error {
 		return cli.NewExitError(fmt.Sprintf("Could not load teams: %s", err), -1)
 	}
 
-	rIdx, _, err := prompts.SelectResource(res, projects, label)
+	rIdx, _, err := prompts.SelectResource(res, projects, name)
 	if err != nil {
 		return prompts.HandleSelectError(err, "Could not select project")
 	}

--- a/cmd/switch.go
+++ b/cmd/switch.go
@@ -21,7 +21,7 @@ func init() {
 		Name:      "switch",
 		Usage:     "Switch to a team context",
 		Category:  "ADMINISTRATIVE",
-		ArgsUsage: "[label]",
+		ArgsUsage: "[team-name]",
 		Flags: []cli.Flag{
 			meFlag(),
 		},
@@ -43,7 +43,7 @@ func switchTeamCmd(cliCtx *cli.Context) error {
 		return err
 	}
 
-	teamLabel, err := optionalArgLabel(cliCtx, 0, "team")
+	teamName, err := optionalArgName(cliCtx, 0, "team")
 	if err != nil {
 		return err
 	}
@@ -71,7 +71,7 @@ func switchTeamCmd(cliCtx *cli.Context) error {
 			return cli.NewExitError("Could not retrieve session: "+err.Error(), -1)
 		}
 
-		teamIdx, _, err := prompts.SelectContext(teams, teamLabel, s.LabelInfo())
+		teamIdx, _, err := prompts.SelectContext(teams, teamName, s.LabelInfo())
 		if err != nil {
 			return prompts.HandleSelectError(err, "Could not select context")
 		}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -9,7 +9,7 @@ import (
 	"github.com/manifoldco/manifold-cli/errs"
 )
 
-func validateName(cliCtx *cli.Context, option string, typeName ...string) (string, error) {
+func validateTitle(cliCtx *cli.Context, option string, typeName ...string) (string, error) {
 	val := cliCtx.String(option)
 	if val == "" {
 		return val, nil
@@ -22,24 +22,24 @@ func validateName(cliCtx *cli.Context, option string, typeName ...string) (strin
 		typeName[0] = option
 	}
 
-	name := manifold.Name(val)
-	if err := name.Validate(nil); err != nil {
+	title := manifold.Name(val)
+	if err := title.Validate(nil); err != nil {
 		return "", errs.NewUsageExitError(cliCtx, cli.NewExitError(
-			fmt.Sprintf("You've provided an invalid %s name!", typeName[0]), -1,
+			fmt.Sprintf("You've provided an invalid %s title!", typeName[0]), -1,
 		))
 	}
 
 	return val, nil
 }
 
-func validateLabel(cliCtx *cli.Context, option string) (string, error) {
+func validateName(cliCtx *cli.Context, option string) (string, error) {
 	val := cliCtx.String(option)
 	if val == "" {
 		return val, nil
 	}
 
-	label := manifold.Label(val)
-	if err := label.Validate(nil); err != nil {
+	name := manifold.Label(val)
+	if err := name.Validate(nil); err != nil {
 		return "", errs.NewUsageExitError(cliCtx, cli.NewExitError(
 			fmt.Sprintf("You've provided an invalid %s!", option), -1,
 		))
@@ -48,7 +48,7 @@ func validateLabel(cliCtx *cli.Context, option string) (string, error) {
 	return val, nil
 }
 
-func requiredLabel(cliCtx *cli.Context, option string) (string, error) {
+func requiredName(cliCtx *cli.Context, option string) (string, error) {
 	val := cliCtx.String(option)
 	if val == "" {
 		return "", errs.NewUsageExitError(cliCtx, cli.NewExitError(
@@ -56,10 +56,10 @@ func requiredLabel(cliCtx *cli.Context, option string) (string, error) {
 		))
 	}
 
-	return validateLabel(cliCtx, option)
+	return validateName(cliCtx, option)
 }
 
-func optionalArgLabel(cliCtx *cli.Context, idx int, name string) (string, error) {
+func optionalArgTitle(cliCtx *cli.Context, idx int, title string) (string, error) {
 	args := cliCtx.Args()
 
 	if len(args) < idx+1 {
@@ -67,10 +67,10 @@ func optionalArgLabel(cliCtx *cli.Context, idx int, name string) (string, error)
 	}
 
 	val := args[idx]
-	l := manifold.Label(val)
+	l := manifold.Name(val)
 	if err := l.Validate(nil); err != nil {
 		return "", errs.NewUsageExitError(cliCtx, cli.NewExitError(
-			fmt.Sprintf("You've provided an invalid %s!", name), -1,
+			fmt.Sprintf("You've provided an invalid %s!", title), -1,
 		))
 	}
 
@@ -85,10 +85,10 @@ func optionalArgName(cliCtx *cli.Context, idx int, name string) (string, error) 
 	}
 
 	val := args[idx]
-	n := manifold.Name(val)
-	if err := n.Validate(nil); err != nil {
+	l := manifold.Label(val)
+	if err := l.Validate(nil); err != nil {
 		return "", errs.NewUsageExitError(cliCtx, cli.NewExitError(
-			fmt.Sprintf("You've provided an invalid %s name", name), -1,
+			fmt.Sprintf("You've provided an invalid %s!", name), -1,
 		))
 	}
 

--- a/cmd/view.go
+++ b/cmd/view.go
@@ -42,7 +42,7 @@ func view(cliCtx *cli.Context) error {
 		return err
 	}
 
-	resourceLabel, err := optionalArgLabel(cliCtx, 0, "resource")
+	resourceName, err := optionalArgName(cliCtx, 0, "resource")
 	if err != nil {
 		return err
 	}
@@ -52,7 +52,7 @@ func view(cliCtx *cli.Context) error {
 		return err
 	}
 
-	project, err := validateLabel(cliCtx, "project")
+	project, err := validateName(cliCtx, "project")
 	if err != nil {
 		return err
 	}
@@ -93,14 +93,14 @@ func view(cliCtx *cli.Context) error {
 	}
 
 	var resource *models.Resource
-	if resourceLabel != "" {
-		resource, err = pickResourcesByLabel(resources, resourceLabel)
+	if resourceName != "" {
+		resource, err = pickResourcesByName(resources, resourceName)
 		if err != nil {
 			return cli.NewExitError(
-				fmt.Sprintf("Failed to find resource \"%s\": %s", resourceLabel, err), -1)
+				fmt.Sprintf("Failed to find resource \"%s\": %s", resourceName, err), -1)
 		}
 	} else {
-		idx, _, err := prompts.SelectResource(resources, projects, resourceLabel)
+		idx, _, err := prompts.SelectResource(resources, projects, resourceName)
 		if err != nil {
 			return prompts.HandleSelectError(err, "Could not select Resource")
 		}
@@ -144,7 +144,7 @@ func view(cliCtx *cli.Context) error {
 	}
 
 	projectID := resource.Body.ProjectID
-	projectLabel := "-"
+	projectName := "-"
 	if projectID != nil {
 		var project *models.Project
 		for _, p := range projects {
@@ -156,15 +156,15 @@ func view(cliCtx *cli.Context) error {
 			cli.NewExitError("Project referenced by resource does not exist: "+
 				err.Error(), -1)
 		}
-		projectLabel = string(project.Body.Label)
+		projectName = string(project.Body.Label)
 	}
 
-	fmt.Println("Use `manifold update [label] --project [project]` to edit your resource")
+	fmt.Println("Use `manifold update [resource-name] --project [project]` to edit your resource")
 	fmt.Println("")
 	w := ansiterm.NewTabWriter(os.Stdout, 0, 0, 8, ' ', 0)
-	fmt.Fprintln(w, fmt.Sprintf("%s\t%s", color.Faint("Name"), color.Bold(resource.Body.Name)))
-	fmt.Fprintln(w, fmt.Sprintf("%s\t%s", color.Faint("Label"), resource.Body.Label))
-	fmt.Fprintln(w, fmt.Sprintf("%s\t%s", color.Faint("Project"), projectLabel))
+	fmt.Fprintln(w, fmt.Sprintf("%s\t%s", color.Faint("Name"), color.Bold(resource.Body.Label)))
+	fmt.Fprintln(w, fmt.Sprintf("%s\t%s", color.Faint("Title"), color.Faint(resource.Body.Name)))
+	fmt.Fprintln(w, fmt.Sprintf("%s\t%s", color.Faint("Project"), projectName))
 	fmt.Fprintln(w, fmt.Sprintf("%s\t%s", color.Faint("State"), status))
 	fmt.Fprintln(w, fmt.Sprintf("%s\t%s", color.Faint("Custom"), isCustom))
 	fmt.Fprintln(w, fmt.Sprintf("%s\t%s", color.Faint("Product"), productName))

--- a/prompts/prompts.go
+++ b/prompts/prompts.go
@@ -353,59 +353,59 @@ func selectTeam(teams []*iModels.Team, prefix, label string, userTuple *[]string
 	return teamIdx, name, err
 }
 
-// ResourceName prompts the user to provide a resource name or to accept empty
+// ResourceTitle prompts the user to provide a resource title or to accept empty
 // to let the system generate one.
-func ResourceName(defaultValue string, autoSelect bool) (string, error) {
+func ResourceTitle(defaultValue string, autoSelect bool) (string, error) {
 	validate := func(input string) error {
 		if len(input) == 0 {
 			return nil
 		}
 
-		n := manifold.Name(input)
-		if err := n.Validate(nil); err != nil {
+		t := manifold.Name(input)
+		if err := t.Validate(nil); err != nil {
+			return promptui.NewValidationError("Please provide a valid resource title")
+		}
+
+		return nil
+	}
+
+	label := "Resource Title (one will be generated if left blank)"
+
+	if autoSelect {
+		err := validate(defaultValue)
+		if err != nil {
+			fmt.Println(promptui.FailedValue(label, defaultValue))
+		} else {
+			fmt.Println(promptui.SuccessfulValue(label, defaultValue))
+		}
+		return defaultValue, err
+	}
+
+	p := promptui.Prompt{
+		Label:    label,
+		Default:  defaultValue,
+		Validate: validate,
+	}
+
+	return p.Run()
+}
+
+// ResourceName prompts the user to provide a label name
+func ResourceName(defaultValue string, autoSelect bool) (string, error) {
+	validate := func(input string) error {
+		if len(input) == 0 {
+			return errors.New("Please provide a resource name")
+		}
+
+		l := manifold.Label(input)
+		if err := l.Validate(nil); err != nil {
 			return errors.New("Please provide a valid resource name")
 		}
 
 		return nil
 	}
 
-	label := "Resource Name (one will be generated if left blank)"
-
-	if autoSelect {
-		err := validate(defaultValue)
-		if err != nil {
-			fmt.Println(promptui.FailedValue(label, defaultValue))
-		} else {
-			fmt.Println(promptui.SuccessfulValue(label, defaultValue))
-		}
-		return defaultValue, err
-	}
-
-	p := promptui.Prompt{
-		Label:    label,
-		Default:  defaultValue,
-		Validate: validate,
-	}
-
-	return p.Run()
-}
-
-// ResourceLabel prompts the user to provide a label name
-func ResourceLabel(defaultValue string, autoSelect bool) (string, error) {
-	validate := func(input string) error {
-		if len(input) == 0 {
-			return errors.New("Please provide a resource label")
-		}
-
-		l := manifold.Label(input)
-		if err := l.Validate(nil); err != nil {
-			return errors.New("Please provide a valid resource label")
-		}
-
-		return nil
-	}
-
-	label := "Resource Label"
+	label := "Resource Name"
 
 	if autoSelect {
 		err := validate(defaultValue)
@@ -427,22 +427,22 @@ func ResourceLabel(defaultValue string, autoSelect bool) (string, error) {
 	return p.Run()
 }
 
-// TeamName prompts the user to enter a new Team name
-func TeamName(defaultValue string, autoSelect bool) (string, error) {
+// TeamTitle prompts the user to enter a new Team title
+func TeamTitle(defaultValue string, autoSelect bool) (string, error) {
 	validate := func(input string) error {
 		if len(input) == 0 {
-			return errors.New("Please provide a valid team name")
+			return errors.New("Please provide a valid team title")
 		}
 
 		l := manifold.Name(input)
 		if err := l.Validate(nil); err != nil {
-			return errors.New("Please provide a valid team name")
+			return errors.New("Please provide a valid team title")
 		}
 
 		return nil
 	}
 
-	label := "Team Name"
+	label := "Team Title"
 
 	if autoSelect {
 		err := validate(defaultValue)
@@ -463,22 +463,22 @@ func TeamName(defaultValue string, autoSelect bool) (string, error) {
 	return p.Run()
 }
 
-// ProjectName prompts the user to enter a new project name
-func ProjectName(defaultValue string, autoSelect bool) (string, error) {
+// ProjectTitle prompts the user to enter a new project title
+func ProjectTitle(defaultValue string, autoSelect bool) (string, error) {
 	validate := func(input string) error {
 		if len(input) == 0 {
-			return errors.New("Please provide a valid project name")
+			return errors.New("Please provide a valid project title")
 		}
 
 		l := manifold.Name(input)
 		if err := l.Validate(nil); err != nil {
-			return errors.New("Please provide a valid project name")
+			return errors.New("Please provide a valid project title")
 		}
 
 		return nil
 	}
 
-	label := "Project Name"
+	label := "Project Title"
 
 	if autoSelect {
 		err := validate(defaultValue)


### PR DESCRIPTION
The upstream code still has the legacy naming scheme, but until it's migrated we will start using the new terminology both in display and throughout the commands (aside from the object structs).