### PR TITLE
Fix output for usage error to show actual command help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `manifold teams remove` will remove a team member or revoke an invite
 
 ### Fixed
+- Amend output for NewUsageError to pull from framework help
 
 ## [0.7.1] - 2017-10-12
 

--- a/errs/errs.go
+++ b/errs/errs.go
@@ -81,19 +81,14 @@ var ErrSomethingWentHorriblyWrong = cli.NewExitError("Something went horribly wr
 // NewUsageExitError returns a new error that includes the usage string for the
 // givne command along with the message from the given error.
 func NewUsageExitError(ctx *cli.Context, err error) error {
-	usage := usageString(ctx)
-	return cli.NewExitError(fmt.Sprintf("%s\n%s", err.Error(), usage), -1)
+	fmt.Printf("Invalid usage: %s\n\n", err.Error())
+	cli.ShowCommandHelpAndExit(ctx, ctx.Command.Name, -1)
+	return nil
 }
 
 // NewErrorExitError creates an ExitError with an appended error message
 func NewErrorExitError(message string, err error) error {
 	return cli.NewExitError(message+"\n"+err.Error(), -1)
-}
-
-func usageString(ctx *cli.Context) string {
-	spacer := "    "
-	return fmt.Sprintf("Usage:\n%s%s %s [comand options] %s",
-		spacer, ctx.App.HelpName, ctx.Command.Name, ctx.Command.ArgsUsage)
 }
 
 type stripeError struct {


### PR DESCRIPTION
Will now show the usage error followed by the proper command help

```
$ manifold config set
Invalid usage: --resource is required

NAME:
   manifold config set - Set one or more config values on a custom resource

USAGE:
   manifold config set [command options] <key=value...>

OPTIONS:
   --team value, -t value      Specify a team [$MANIFOLD_TEAM]
   --me, -m                    Specify the action should not be done with a team
   --resource value, -r value  Use this resource
```