### PR TITLE
Fix error and success state for manifold config set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `manifold teams remove` will remove a team member or revoke an invite
 
 ### Fixed
+- Update success and failure output for `manifold config set`
 
 ## [0.7.1] - 2017-10-12
 


### PR DESCRIPTION
Success

```$ manifold config set -r custom-config a=b
Your configuration has been updated.

Use `manifold export` to review your config.
```

Invalid usage

```
$ manifold config set -r custom-config
Invalid usage: At least one key must be present

NAME:
   manifold config set - Set one or more config values on a custom resource

USAGE:
   manifold config set [command options] <key=value...>

OPTIONS:
   --team value, -t value      Specify a team [$MANIFOLD_TEAM]
   --me, -m                    Specify the action should not be done with a team
   --resource value, -r value  Use this resource
```