### PR TITLE
RFC: Add a timeout to waitForOp which encourages users to manually check status

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -133,18 +133,14 @@ func deleteCmd(cliCtx *cli.Context) error {
 		return cli.NewExitError("Resource not deleted", -1)
 	}
 
-	spin := prompts.NewSpinner(fmt.Sprintf("Deleting resource \"%s\"", resource.Body.Label))
-	if !dontWait {
-		spin.Start()
-	}
-
+	prompts.SpinStart(fmt.Sprintf("Deleting resource \"%s\"", resource.Body.Label))
 	err = deleteResource(ctx, cfg, teamID, s, resource, client.Provisioning, dontWait)
+	prompts.SpinStop()
 	if err != nil {
+		if err == errWaitForOpTimeout {
+			return handleWaitForOpTimeout()
+		}
 		return cli.NewExitError(fmt.Sprintf("Failed to delete resource: %s", err), -1)
-	}
-
-	if !dontWait {
-		spin.Stop()
 	}
 
 	fmt.Printf("Your instance \"%s\" has been deleted\n", resource.Body.Label)

--- a/cmd/resize.go
+++ b/cmd/resize.go
@@ -104,11 +104,13 @@ func resizeResourceCmd(cliCtx *cli.Context) error {
 	}
 	p := plans[pIdx]
 
-	spin := prompts.NewSpinner(fmt.Sprintf("Updating resource \"%s\"", r.Body.Label))
-	spin.Start()
-	defer spin.Stop()
-
-	if err := resizeResource(ctx, r, p, client, teamID, userID, dontWait); err != nil {
+	prompts.SpinStart(fmt.Sprintf("Updating resource \"%s\"", r.Body.Label))
+	err = resizeResource(ctx, r, p, client, teamID, userID, dontWait)
+	prompts.SpinStop()
+	if err != nil {
+		if err == errWaitForOpTimeout {
+			return handleWaitForOpTimeout()
+		}
 		return cli.NewExitError(fmt.Sprintf("Could not update resource \"%s\": %s", string(r.Body.Label), err), -1)
 	}
 


### PR DESCRIPTION
```
$ manifold create
✔ Select Product: JawsDB Mysql (jawsdb-mysql)
✔ Select Plan: Kitefin (kitefin) - $5/month
✔ Select Region: AWS - EU West 1 (Ireland) (aws::eu-west-1)
✔ Resource Name (one will be generated if left blank):
Your current operation is taking too long, so we have stopped waiting.

You can still monitor its status using `manifold list`
```