### PR TITLE
Use optionalArgName for team name prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Update success and failure output for `manifold config set`
 - Prevent error during resize attempt of custom resource
 - Amend output for NewUsageError to pull from framework help
+- `teams create` can be used non-interatively
 
 ## [0.7.1] - 2017-10-12
 

--- a/cmd/teams.go
+++ b/cmd/teams.go
@@ -101,7 +101,7 @@ func createTeamCmd(cliCtx *cli.Context) error {
 		return err
 	}
 
-	teamName, err := optionalArgLabel(cliCtx, 0, "team")
+	teamName, err := optionalArgName(cliCtx, 0, "team")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix non-interactive teams creation, accept a name instead of a label for the first arg