### PR TITLE
Allow login from env var MANIFOLD_API_TOKEN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `manifold teams remove` will remove a team member or revoke an invite
 - `manifold context` command to display current account and context
 - `manifold tokens add` will create a new API token
+- `MANIFOLD_API_TOKEN` as means for authenticating
 
 ### Fixed
 - Update success and failure output for `manifold config set`

--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -25,6 +25,9 @@ type Analytics struct {
 
 // Track submits an event to the identity service
 func (a *Analytics) Track(ctx context.Context, name string, params *map[string]string) error {
+	if !a.session.IsUser() {
+		return nil
+	}
 	if !a.session.Authenticated() {
 		return errs.ErrMustLogin
 	}

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -56,6 +56,9 @@ func contextLookup(cliCtx *cli.Context) error {
 		}
 	} else {
 		me = true
+		if !s.IsUser() {
+			return errUserActionAsTeam
+		}
 	}
 	if !cliCtx.Bool("short") || me {
 		s, err = session.Retrieve(ctx, cfg)
@@ -89,14 +92,16 @@ func contextLookup(cliCtx *cli.Context) error {
 			return color.Color(ansiterm.Gray, i)
 		}
 
-		fmt.Println(color.Bold("Account"))
-		w := ansiterm.NewTabWriter(os.Stdout, 0, 0, 8, ' ', 0)
-		fmt.Fprintln(w, fmt.Sprintf("%s\t%s", faint("Name"), usr.Body.Name))
-		fmt.Fprintln(w, fmt.Sprintf("%s\t%s", faint("Email"), usr.Body.Email))
-		w.Flush()
-		fmt.Println("")
+		if s.IsUser() {
+			fmt.Println(color.Bold("Account"))
+			w := ansiterm.NewTabWriter(os.Stdout, 0, 0, 8, ' ', 0)
+			fmt.Fprintln(w, fmt.Sprintf("%s\t%s", faint("Name"), usr.Body.Name))
+			fmt.Fprintln(w, fmt.Sprintf("%s\t%s", faint("Email"), usr.Body.Email))
+			w.Flush()
+			fmt.Println("")
+		}
 		fmt.Println(color.Bold("Context"))
-		w = ansiterm.NewTabWriter(os.Stdout, 0, 0, 8, ' ', 0)
+		w := ansiterm.NewTabWriter(os.Stdout, 0, 0, 8, ' ', 0)
 		fmt.Fprintln(w, fmt.Sprintf("%s\t%s", faint("Type"), ctxType))
 		fmt.Fprintln(w, fmt.Sprintf("%s\t%s", faint("Value"), ctxValue))
 		w.Flush()

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -265,6 +265,9 @@ func createResource(ctx context.Context, cfg *config.Config, teamID *manifold.ID
 	op.Body.SetCreatedAt(&curTime)
 	op.Body.SetUpdatedAt(&curTime)
 	if teamID == nil {
+		if !s.IsUser() {
+			return nil, errUserActionAsTeam
+		}
 		op.Body.SetUserID(&s.User().ID)
 	} else {
 		op.Body.SetTeamID(teamID)

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -182,6 +182,9 @@ func deleteResource(ctx context.Context, cfg *config.Config, teamID *manifold.ID
 	op.Body.SetCreatedAt(&curTime)
 	op.Body.SetUpdatedAt(&curTime)
 	if teamID == nil {
+		if !s.IsUser() {
+			return errUserActionAsTeam
+		}
 		op.Body.SetUserID(&s.User().ID)
 	} else {
 		op.Body.SetTeamID(teamID)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -122,13 +122,19 @@ func list(cliCtx *cli.Context) error {
 				// Get catalog data
 				product, err := catalog.GetProduct(*resource.Body.ProductID)
 				if err != nil {
-					cli.NewExitError("Product referenced by resource does not exist: "+
+					return cli.NewExitError("Product referenced by resource does not exist: "+
 						err.Error(), -1)
+				}
+				if product == nil {
+					return cli.NewExitError("Product not found", -1)
 				}
 				plan, err := catalog.GetPlan(*resource.Body.PlanID)
 				if err != nil {
-					cli.NewExitError("Plan referenced by resource does not exist: "+
+					return cli.NewExitError("Plan referenced by resource does not exist: "+
 						err.Error(), -1)
+				}
+				if plan == nil {
+					return cli.NewExitError("Product not found", -1)
 				}
 
 				rType = fmt.Sprintf("%s %s", product.Body.Name, plan.Body.Name)
@@ -326,6 +332,11 @@ func userEmail(ctx context.Context) (string, error) {
 	s, err := session.Retrieve(ctx, cfg)
 	if err != nil {
 		return "", cli.NewExitError("Could not retrieve session: "+err.Error(), -1)
+	}
+
+	// If the session is not a user, we cannot return their identity
+	if !s.IsUser() {
+		return "", nil
 	}
 
 	userDetail := s.LabelInfo()

--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -104,14 +104,17 @@ func createProjectCmd(cliCtx *cli.Context) error {
 		return err
 	}
 
-	userID, err := loadUserID(ctx)
-	if err != nil {
-		return err
+	userID, userIDErr := loadUserID(ctx)
+	if userIDErr != nil && userIDErr != errUserActionAsTeam {
+		return userIDErr
 	}
 
-	teamID, err := validateTeamID(cliCtx)
-	if err != nil {
-		return err
+	teamID, teamIDErr := validateTeamID(cliCtx)
+	if teamIDErr != nil {
+		return teamIDErr
+	}
+	if teamID == nil && userIDErr == errUserActionAsTeam {
+		return errUserActionAsTeam
 	}
 
 	projectName, err := optionalArgName(cliCtx, 0, "name")

--- a/cmd/resize.go
+++ b/cmd/resize.go
@@ -52,14 +52,17 @@ func resizeResourceCmd(cliCtx *cli.Context) error {
 		return err
 	}
 
-	userID, err := loadUserID(ctx)
-	if err != nil {
-		return err
+	userID, userIDErr := loadUserID(ctx)
+	if userIDErr != nil && userIDErr != errUserActionAsTeam {
+		return userIDErr
 	}
 
-	teamID, err := validateTeamID(cliCtx)
-	if err != nil {
-		return err
+	teamID, teamIDErr := validateTeamID(cliCtx)
+	if teamIDErr != nil {
+		return teamIDErr
+	}
+	if teamID == nil && userIDErr == errUserActionAsTeam {
+		return errUserActionAsTeam
 	}
 
 	dontWait := cliCtx.Bool("no-wait")

--- a/cmd/switch.go
+++ b/cmd/switch.go
@@ -71,7 +71,12 @@ func switchTeamCmd(cliCtx *cli.Context) error {
 			return cli.NewExitError("Could not retrieve session: "+err.Error(), -1)
 		}
 
-		teamIdx, _, err := prompts.SelectContext(teams, teamName, s.LabelInfo())
+		var userLabel *[]string
+		if s.IsUser() {
+			userLabel = s.LabelInfo()
+		}
+
+		teamIdx, _, err := prompts.SelectContext(teams, teamName, userLabel)
 		if err != nil {
 			return prompts.HandleSelectError(err, "Could not select context")
 		}

--- a/specs/identity.yaml
+++ b/specs/identity.yaml
@@ -228,6 +228,9 @@ paths:
           description: A user object.
           schema:
             $ref: '#/definitions/User'
+        400:
+          description: Bad request
+          schema: { $ref: '#/definitions/Error' }
         401:
           description: Unknown token, or token not owned the the requester
           schema:


### PR DESCRIPTION
Closes https://github.com/manifoldco/engineering/issues/3163

This authenticates a machine using the API token instead of a JWT returned from the login flow.

```
MANIFOLD_API_TOKEN=[token] manifold list
```