### PR TITLE
Do not duplicate -t for use with title flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Amend output for NewUsageError to pull from framework help
 - `teams create` can be used non-interatively
 - Terminology has changed: Name becomes Title, Label becomes Name
+- Remove -t from title flag to prevent panic
 
 ## [0.7.1] - 2017-10-12
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -14,7 +14,7 @@ func formatFlag(defaultValue, description string) cli.Flag {
 
 func titleFlag() cli.Flag {
 	return cli.StringFlag{
-		Name:   "title, t",
+		Name:   "title",
 		Usage:  "Specify a title to be used",
 		Value:  "",
 		EnvVar: "MANIFOLD_TITLE",


### PR DESCRIPTION
Closes https://github.com/manifoldco/manifold-cli/issues/164

We can leave it without a shortflag for now, rather than an obscure other letter