### PR TITLE
Fix project create due to Name/Title change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Fixed
+- Project create failure due to Name/Title change
+
 ## [0.8.1] - 2017-10-24
 
 ### Added

--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -117,7 +117,7 @@ func createProjectCmd(cliCtx *cli.Context) error {
 		return errUserActionAsTeam
 	}
 
-	projectTitle, err := optionalArgTitle(cliCtx, 0, "name")
+	projectTitle, err := optionalArgTitle(cliCtx, 0, "title")
 	if err != nil {
 		return err
 	}
@@ -125,7 +125,7 @@ func createProjectCmd(cliCtx *cli.Context) error {
 	autoSelect := projectTitle != ""
 	projectTitle, err = prompts.ProjectTitle(projectTitle, autoSelect)
 	if err != nil {
-		return prompts.HandleSelectError(err, "Failed to name project")
+		return prompts.HandleSelectError(err, "Failed to select project title")
 	}
 
 	params := projectClient.NewPostProjectsParamsWithContext(ctx)

--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -39,7 +39,7 @@ func init() {
 				Name:      "create",
 				Usage:     "Create a new project",
 				Flags:     teamFlags,
-				ArgsUsage: "[project-name]",
+				ArgsUsage: "[project-title]",
 				Action: middleware.Chain(middleware.EnsureSession,
 					middleware.LoadTeamPrefs, createProjectCmd),
 			},
@@ -117,13 +117,13 @@ func createProjectCmd(cliCtx *cli.Context) error {
 		return errUserActionAsTeam
 	}
 
-	projectName, err := optionalArgName(cliCtx, 0, "name")
+	projectTitle, err := optionalArgTitle(cliCtx, 0, "name")
 	if err != nil {
 		return err
 	}
 
-	autoSelect := projectName != ""
-	projectTitle, err := prompts.ProjectTitle(projectName, autoSelect)
+	autoSelect := projectTitle != ""
+	projectTitle, err = prompts.ProjectTitle(projectTitle, autoSelect)
 	if err != nil {
 		return prompts.HandleSelectError(err, "Failed to name project")
 	}
@@ -131,7 +131,7 @@ func createProjectCmd(cliCtx *cli.Context) error {
 	params := projectClient.NewPostProjectsParamsWithContext(ctx)
 	body := &mModels.CreateProjectBody{
 		Name:  manifold.Name(projectTitle),
-		Label: generateName(projectName),
+		Label: generateName(projectTitle),
 	}
 
 	if teamID == nil {


### PR DESCRIPTION
Before:
```
$ ./bin/manifold projects create
✔ Project Title: local
Could not create project: bad_request: validation failure list:
validation failure list:
bad_request: Invalid label
```

After:
```
% ./bin/manifold projects create
✔ Project Title: Local
Your project 'Local' has been created
```