### PR TITLE
Normalize name/title logic and translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Project create failure due to Name/Title change
 - Set-role should error before prompts
 - Context would panic due to missing session
+- Change logic for inferring object title from name
 
 ## [0.8.1] - 2017-10-24
 

--- a/clients/teams.go
+++ b/clients/teams.go
@@ -12,6 +12,7 @@ import (
 // TeamMembersCount groups a team name with the amount of members the team has
 type TeamMembersCount struct {
 	Name    string
+	Title   string
 	Members int
 }
 
@@ -62,7 +63,8 @@ func FetchTeamsMembersCount(ctx context.Context, c *iClient.Identity) ([]TeamMem
 
 	for _, t := range teams {
 		id := t.ID.String()
-		name := string(t.Body.Name)
+		name := string(t.Body.Label)
+		title := string(t.Body.Name)
 
 		go func() {
 			members, err := FetchTeamMembers(ctx, id, c)
@@ -74,6 +76,7 @@ func FetchTeamsMembersCount(ctx context.Context, c *iClient.Identity) ([]TeamMem
 
 			res <- TeamMembersCount{
 				Name:    name,
+				Title:   title,
 				Members: len(members),
 			}
 		}()

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -66,7 +66,7 @@ func initDir(cliCtx *cli.Context) error {
 		return errs.ErrNoProjects
 	}
 
-	pIdx, _, err := prompts.SelectProject(ps, projectName, true)
+	pIdx, _, err := prompts.SelectProject(ps, projectName, true, true)
 	if err != nil {
 		return prompts.HandleSelectError(err, "Could not select project.")
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,11 +3,14 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/urfave/cli"
 
+	"github.com/manifoldco/go-manifold"
 	"github.com/manifoldco/manifold-cli/config"
 	"github.com/manifoldco/manifold-cli/plugins"
+	"github.com/manifoldco/manifold-cli/prompts"
 )
 
 var cmds []cli.Command
@@ -66,4 +69,65 @@ var helpCommand = cli.Command{
 		cli.ShowAppHelp(c)
 		return nil
 	},
+}
+
+// generateName makes a title lowercase and replace spaces with dashes
+func generateName(title string) manifold.Label {
+	name := strings.Replace(strings.ToLower(title), " ", "-", -1)
+	return manifold.Label(name)
+}
+
+// generateTitle makes a name capitalized and replace dashes with spaaces
+func generateTitle(name string) manifold.Name {
+	title := strings.Title(strings.Replace(name, "-", " ", -1))
+	return manifold.Name(title)
+}
+
+// promptNameAndTitle encapsulates the logic for accepting a name as the first
+// positional argument (optionally), and a title flag (optionally)
+// returning generated values accepted by the user
+func promptNameAndTitle(ctx *cli.Context, objectName string, shouldInferTitle, allowEmpty bool) (string, string, error) {
+	// The user may supply a name value as the first positional arg
+	argName, err := optionalArgName(ctx, 0, "name")
+	if err != nil {
+		return "", "", err
+	}
+
+	// The user may supply a title value from a flag, validate it
+	flagTitle := ctx.String("title")
+
+	// Create the title based on the name argument
+	return createNameAndTitle(ctx, objectName, argName, flagTitle, shouldInferTitle, true, allowEmpty)
+}
+
+func createNameAndTitle(ctx *cli.Context, objectName, argName, flagTitle string, shouldInferTitle, shouldAccept, allowEmpty bool) (string, string, error) {
+	var name, title string
+
+	// If no name value is supplied, prompt for it
+	// otherwise validate the given value
+	shouldAcceptName := shouldAccept && argName != ""
+	nameValue, err := prompts.Name(objectName, argName, shouldAcceptName, allowEmpty)
+	if err != nil {
+		return name, title, err
+	}
+	name = nameValue
+
+	// We will automatically validate/accept a title given as flag
+	shouldAcceptTitle := shouldAccept && flagTitle != ""
+	// If we shouldn't infer the title, do not automatically accept a title value
+	if !shouldInferTitle {
+		shouldAcceptTitle = false
+	}
+	defaultTitle := flagTitle
+	if flagTitle == "" && shouldInferTitle {
+		// If no flag is present, we will infer the title from the validated name
+		defaultTitle = string(generateTitle(name))
+	}
+	titleValue, err := prompts.Title(objectName, defaultTitle, shouldAcceptTitle, allowEmpty)
+	if err != nil {
+		return name, title, err
+	}
+	title = titleValue
+
+	return name, title, nil
 }

--- a/prompts/prompts.go
+++ b/prompts/prompts.go
@@ -26,23 +26,24 @@ const NumberMask = '#'
 
 var errBad = errors.New("Bad Value")
 
-// ResourceTitle prompts the user to provide a resource title or to accept empty
-// to let the system generate one.
-func ResourceTitle(defaultValue string, autoSelect bool) (string, error) {
+// Title prompts the user to provide a Title value
+func Title(field, defaultValue string, autoSelect, allowEmpty bool) (string, error) {
+	field = strings.Title(field)
+
 	validate := func(input string) error {
-		if len(input) == 0 {
+		if allowEmpty && len(input) == 0 {
 			return nil
 		}
 
 		t := manifold.Name(input)
 		if err := t.Validate(nil); err != nil {
-			return errors.New("Please provide a valid resource title")
+			return fmt.Errorf("Please provide a valid %s title", field)
 		}
 
 		return nil
 	}
 
-	label := "Resource Title (one will be generated if left blank)"
+	label := fmt.Sprintf("New %s Title", field)
 
 	if autoSelect {
 		err := validate(defaultValue)
@@ -63,22 +64,24 @@ func ResourceTitle(defaultValue string, autoSelect bool) (string, error) {
 	return p.Run()
 }
 
-// ResourceName prompts the user to provide a label name
-func ResourceName(defaultValue string, autoSelect bool) (string, error) {
+// Name prompts the user to provide a Name value
+func Name(field, defaultValue string, autoSelect, allowEmpty bool) (string, error) {
+	field = strings.Title(field)
+
 	validate := func(input string) error {
 		if len(input) == 0 {
-			return errors.New("Please provide a resource name")
+			return fmt.Errorf("Please provide a %s name", field)
 		}
 
 		l := manifold.Label(input)
 		if err := l.Validate(nil); err != nil {
-			return errors.New("Please provide a valid resource name")
+			return fmt.Errorf("Please provide a valid %s name", field)
 		}
 
 		return nil
 	}
 
-	label := "Resource Name"
+	label := fmt.Sprintf("New %s Name", field)
 
 	if autoSelect {
 		err := validate(defaultValue)
@@ -98,78 +101,27 @@ func ResourceName(defaultValue string, autoSelect bool) (string, error) {
 	}
 
 	return p.Run()
+}
+
+// ResourceTitle prompts the user to provide a resource title or to accept empty
+// to let the system generate one.
+func ResourceTitle(defaultValue string, autoSelect bool) (string, error) {
+	return Title("resource", defaultValue, autoSelect, true)
+}
+
+// ResourceName prompts the user to provide a label name
+func ResourceName(defaultValue string, autoSelect bool) (string, error) {
+	return Name("resource", defaultValue, autoSelect, false)
 }
 
 // TeamTitle prompts the user to enter a new Team title
 func TeamTitle(defaultValue string, autoSelect bool) (string, error) {
-	validate := func(input string) error {
-		if len(input) == 0 {
-			return errors.New("Please provide a valid team title")
-		}
-
-		l := manifold.Name(input)
-		if err := l.Validate(nil); err != nil {
-			return errors.New("Please provide a valid team title")
-		}
-
-		return nil
-	}
-
-	label := "Team Title"
-
-	if autoSelect {
-		err := validate(defaultValue)
-		if err != nil {
-			fmt.Println(templates.PromptFailure(label, defaultValue))
-		} else {
-			fmt.Println(templates.PromptSuccess(label, defaultValue))
-		}
-		return defaultValue, err
-	}
-
-	p := promptui.Prompt{
-		Label:    label,
-		Default:  defaultValue,
-		Validate: validate,
-	}
-
-	return p.Run()
+	return Title("team", defaultValue, autoSelect, false)
 }
 
 // ProjectTitle prompts the user to enter a new project title
 func ProjectTitle(defaultValue string, autoSelect bool) (string, error) {
-	validate := func(input string) error {
-		if len(input) == 0 {
-			return errors.New("Please provide a valid project title")
-		}
-
-		l := manifold.Name(input)
-		if err := l.Validate(nil); err != nil {
-			return errors.New("Please provide a valid project title")
-		}
-
-		return nil
-	}
-
-	label := "Project Title"
-
-	if autoSelect {
-		err := validate(defaultValue)
-		if err != nil {
-			fmt.Println(templates.PromptFailure(label, defaultValue))
-		} else {
-			fmt.Println(templates.PromptSuccess(label, defaultValue))
-		}
-		return defaultValue, err
-	}
-
-	p := promptui.Prompt{
-		Label:    label,
-		Default:  defaultValue,
-		Validate: validate,
-	}
-
-	return p.Run()
+	return Title("project", defaultValue, autoSelect, false)
 }
 
 // TokenDescription prompts the user to enter a token description

--- a/prompts/selects.go
+++ b/prompts/selects.go
@@ -154,7 +154,7 @@ func SelectRegion(list []*cModels.Region) (int, string, error) {
 }
 
 // SelectProject prompts the user to select a project from the given list.
-func SelectProject(list []*mModels.Project, name string, emptyOption bool) (int, string, error) {
+func SelectProject(list []*mModels.Project, name string, emptyOption, showResult bool) (int, string, error) {
 	projects := templates.Projects(list)
 	tpls := templates.TplProject
 
@@ -175,8 +175,10 @@ func SelectProject(list []*mModels.Project, name string, emptyOption bool) (int,
 			return 0, "", errs.ErrProjectNotFound
 		}
 
-		msg := templates.SelectSuccess(tpls, projects[idx])
-		fmt.Println(msg)
+		if showResult {
+			msg := templates.SelectSuccess(tpls, projects[idx])
+			fmt.Println(msg)
+		}
 
 		return idx, name, nil
 	}


### PR DESCRIPTION
- Accept `--title` tag throughout create/update commands
- Use first positional arg to reverse engineer title if flag not present
- Prompt to confirm both values

### Examples

Both fields prompted for
```
~ $ manifold create
✔ New Resource Name: new-resource-name
✔ New Resource Title: New Resource Name
^C
```
Both values autofilled from args/flags
```
~ $ manifold create whatever-resource-name --title "A resource title otherwise"
✔ New Resource Name: whatever-resource-name
✔ New Resource Title: A resource title otherwise
^C
```
Name typed in, title autofilled from flag`
```
~ $ manifold create --title "A resource title otherwise"
✔ New Resource Name: some-value
✔ New Resource Title: A resource title otherwise
^C
```