### PR TITLE
Create and view resources from Unlisted Plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Added
+- Support for creating and viewing resources from unlisted plans
 
 ### Fixed
-
+- Resize will no longer crash due to uninitialized Analytics
 
 ## [0.9.1] - 2017-10-27
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -132,20 +132,31 @@ func create(cliCtx *cli.Context) error {
 			return prompts.HandleSelectError(err, "Could not select product.")
 		}
 
-		plans := filterPlansByProductID(catalog.Plans(), products[productIdx].ID)
-		planIdx, _, err := prompts.SelectPlan(plans, planName)
-		if err != nil {
-			return prompts.HandleSelectError(err, "Could not select plan.")
+		if planName != "" {
+			plan, err = catalog.FetchPlanByLabel(ctx, products[productIdx].ID, planName)
+			if err != nil {
+				return prompts.HandleSelectError(err, "Plan does not exist.")
+			}
+			_, _, err = prompts.SelectPlan([]*cModels.Plan{plan}, planName)
+			if err != nil {
+				return prompts.HandleSelectError(err, "Could not select plan.")
+			}
+		} else {
+			plans := filterPlansByProductID(catalog.Plans(), products[productIdx].ID)
+			planIdx, _, err := prompts.SelectPlan(plans, planName)
+			if err != nil {
+				return prompts.HandleSelectError(err, "Could not select plan.")
+			}
+			plan = plans[planIdx]
 		}
 
-		regions := filterRegionsForPlan(catalog.Regions(), plans[planIdx].Body.Regions)
+		regions := filterRegionsForPlan(catalog.Regions(), plan.Body.Regions)
 		regionIdx, _, err := prompts.SelectRegion(regions)
 		if err != nil {
 			return prompts.HandleSelectError(err, "Could not select region.")
 		}
 
 		product = products[productIdx]
-		plan = plans[planIdx]
 		region = regions[regionIdx]
 	}
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -130,8 +130,12 @@ func list(cliCtx *cli.Context) error {
 				}
 				plan, err := catalog.GetPlan(*resource.Body.PlanID)
 				if err != nil {
-					return cli.NewExitError("Plan referenced by resource does not exist: "+
-						err.Error(), -1)
+					// Try and get unlisted plan not in local cache
+					plan, err = catalog.FetchPlanById(ctx, *resource.Body.PlanID)
+					if err != nil {
+						return cli.NewExitError("Plan referenced by resource does not exist: "+
+							err.Error(), -1)
+					}
 				}
 				if plan == nil {
 					return cli.NewExitError("Product not found", -1)

--- a/cmd/resize.go
+++ b/cmd/resize.go
@@ -68,7 +68,7 @@ func resizeResourceCmd(cliCtx *cli.Context) error {
 	dontWait := cliCtx.Bool("no-wait")
 	planName := cliCtx.String("plan")
 
-	client, err := api.New(api.Catalog, api.Marketplace, api.Provisioning)
+	client, err := api.New(api.Analytics, api.Catalog, api.Marketplace, api.Provisioning)
 	if err != nil {
 		return err
 	}

--- a/cmd/view.go
+++ b/cmd/view.go
@@ -123,8 +123,12 @@ func view(cliCtx *cli.Context) error {
 		}
 		plan, err := catalog.GetPlan(*resource.Body.PlanID)
 		if err != nil {
-			cli.NewExitError("Plan referenced by resource does not exist: "+
-				err.Error(), -1)
+			// Try and get unlisted plan not in local cache
+			plan, err = catalog.FetchPlanById(ctx, *resource.Body.PlanID)
+			if err != nil {
+				return cli.NewExitError("Plan referenced by resource does not exist: "+
+					err.Error(), -1)
+			}
 		}
 		region, err := catalog.GetRegion(*resource.Body.RegionID)
 		if err != nil {

--- a/data/catalog/plans.go
+++ b/data/catalog/plans.go
@@ -1,0 +1,41 @@
+package catalog
+
+import (
+	"context"
+	"errors"
+
+	"github.com/manifoldco/go-manifold"
+	hierr "github.com/reconquest/hierr-go"
+
+	catalogClientPlan "github.com/manifoldco/manifold-cli/generated/catalog/client/plan"
+	catalogModels "github.com/manifoldco/manifold-cli/generated/catalog/models"
+)
+
+func (c *Catalog) FetchPlanByLabel(ctx context.Context,
+	productID manifold.ID, planLabel string) (*catalogModels.Plan, error) {
+	// Get plans for known productIDs
+	planParams := catalogClientPlan.NewGetPlansParamsWithContext(ctx)
+	planParams.SetProductID([]string{productID.String()})
+	planParams.SetLabel(&planLabel)
+	plans, err := c.client.Plan.GetPlans(planParams, nil)
+	if err != nil {
+		return nil, hierr.Errorf(err,
+			"Failed to fetch the latest product plan data")
+	}
+	if len(plans.Payload) < 1 {
+		return nil, errors.New("Plan does not exist")
+	}
+	return plans.Payload[0], nil
+}
+
+func (c *Catalog) FetchPlanById(ctx context.Context, planID manifold.ID) (*catalogModels.Plan, error) {
+	// Get plan by id
+	planParams := catalogClientPlan.NewGetPlansIDParamsWithContext(ctx)
+	planParams.SetID(planID.String())
+	plan, err := c.client.Plan.GetPlansID(planParams, nil)
+	if err != nil {
+		return nil, hierr.Errorf(err,
+			"Failed to fetch the latest product plan data")
+	}
+	return plan.Payload, nil
+}


### PR DESCRIPTION
This allows a resource to be created from an unlisted plan
The way we were querying plan details on create, list and view was incompatible with unlisted plans
This also fixes the broken `resize` command

Relates manifoldco/engineering#3248