### PR TITLE
Disable global spinner animation if not terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Resize will no longer crash due to uninitialized Analytics
 - Ask for resource name/title after resource settings has been selected
+- Disable spinner animation when piping output
 
 ## [0.9.1] - 2017-10-27
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -406,6 +406,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "fcc0f6548164c870e446bc5f48c769a78014252753175497f7e07b87d89c1795"
+  inputs-digest = "11d707a07722179b5a751203abefe88dc02d86f0d4b5210428155fd6d0cba0c3"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -80,3 +80,7 @@ required=[
 [[constraint]]
   name = "github.com/go-swagger/go-swagger"
   version = "0.10.0"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/chzyer/readline"

--- a/prompts/spinner.go
+++ b/prompts/spinner.go
@@ -1,12 +1,22 @@
 package prompts
 
 import (
+	"os"
 	"time"
 
 	"github.com/briandowns/spinner"
+	"github.com/chzyer/readline"
 )
 
+// IsInteractive tells whether a terminal support interaction, such as prompts
+// and colors.
+var IsInteractive = true
+
 var globalSpinner = spinner.New(spinner.CharSets[11], 100*time.Millisecond)
+
+func init() {
+	IsInteractive = readline.IsTerminal(int(os.Stdout.Fd()))
+}
 
 // NewSpinner returns a customized spinner
 func NewSpinner(suffix string) *spinner.Spinner {
@@ -19,6 +29,10 @@ func NewSpinner(suffix string) *spinner.Spinner {
 
 // SpinStart starts the spinning animation for the global spinner
 func SpinStart(suffix string) {
+	if !IsInteractive {
+		return
+	}
+
 	if suffix == "" {
 		globalSpinner.Suffix = ""
 	} else {
@@ -29,5 +43,9 @@ func SpinStart(suffix string) {
 
 // SpinStop stopts the Spinner animation for the global spinner
 func SpinStop() {
+	if !IsInteractive {
+		return
+	}
+
 	globalSpinner.Stop()
 }


### PR DESCRIPTION
Added readline dependency already required by promptui.  The animation still works when not piping the output.

Before:

```shell
manifold export > file
cat file
⣾ Fetching Resources ^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H                     ^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H⣽ Fetching Resources ^H^H^H^H
    ^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H                     ^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H⣻ Fetching Resources ^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^
    H^H^H                     ^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H⢿ Fetching Resources ^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H                     ^H^
    H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H⡿ Fetching Resources ^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H                     ^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H^H
    ^H^H^H^H^H# database
PASSWORD=s3cr3t
```

After:

```shell
manifold export > file
cat file
# database
PASSWORD=s3cr3t
```