### PR TITLE
 Check env HOME before calling user.Current() 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+## [0.10.1] - 2017-11-15
+
+### Fixed
+
+- `os/user.Current` when cgo is disabled
+
 ## [0.10.0] - 2017-11-03
 
 ### Added

--- a/config/config.go
+++ b/config/config.go
@@ -135,16 +135,11 @@ func checkPermissions(path string) error {
 
 // RCPath returns the absolute path to the ~/.manifoldrc file
 func RCPath() (string, error) {
-	u, err := user.Current()
+	home, err := UserHome()
 	if err != nil {
 		return "", err
 	}
-
-	if u.HomeDir == "" {
-		return "", ErrMissingHomeDir
-	}
-
-	return path.Join(u.HomeDir, rcFilename), nil
+	return path.Join(home, rcFilename), nil
 }
 
 // Config represents the configuration which is stored inside a ~/.manifoldrc
@@ -333,4 +328,21 @@ func isSystemRoot(path string) bool {
 	}
 
 	return os.PathSeparator == path[rootPathLength-1]
+}
+
+func UserHome() (string, error) {
+	home := os.Getenv("HOME")
+	if home != "" {
+		return home, nil
+	}
+	u, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+
+	if u.HomeDir == "" {
+		return "", ErrMissingHomeDir
+	}
+
+	return u.HomeDir, nil
 }

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"os/user"
 	"path"
 	"runtime"
 	"strings"
@@ -27,24 +26,16 @@ const (
 // ErrFailedToRead is returned when you the plugins directory cannot be read
 var ErrFailedToRead = errors.New("Failed to read plugins directory")
 
-// ErrMissingHomeDir represents an error when a home directory could not be found
-var ErrMissingHomeDir = errors.New("Could not find Home Directory")
-
 // ErrBadPluginRepository represents an error when the plugin url is invalidu
 var ErrBadPluginRepository = errors.New("Invalid repository URL")
 
 // Path returns the plugin directory's path
 func Path() (string, error) {
-	u, err := user.Current()
+	home, err := config.UserHome()
 	if err != nil {
 		return "", err
 	}
-
-	if u.HomeDir == "" {
-		return "", ErrMissingHomeDir
-	}
-
-	return path.Join(u.HomeDir, directory), nil
+	return path.Join(home, directory), nil
 }
 
 // Executable returns the executable path


### PR DESCRIPTION
`os/user.Current` may fail when the binary is cross-compiled with CGO disabled.

Closes https://github.com/manifoldco/engineering/issues/3317