### PR TITLE
Add role flag to teams invite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- `--role` flag to `teams invite`
+
 ### Fixed
 
 ## [0.10.1] - 2017-11-15

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -124,3 +124,10 @@ func openFlag() cli.Flag {
 		EnvVar: "MANIFOLD_OPEN_BROWSER",
 	}
 }
+
+func roleFlag() cli.Flag {
+	return cli.StringFlag{
+		Name:  "role",
+		Usage: "Specify a team role to be used",
+	}
+}

--- a/cmd/teams.go
+++ b/cmd/teams.go
@@ -58,7 +58,7 @@ func init() {
 				Name:      "invite",
 				ArgsUsage: "[email] [display-name]",
 				Usage:     "Invite a user to join a team",
-				Flags:     teamFlags,
+				Flags:     append(teamFlags, roleFlag()),
 				Action: middleware.Chain(middleware.LoadDirPrefs, middleware.EnsureSession,
 					middleware.LoadTeamPrefs, inviteToTeamCmd),
 			},
@@ -199,9 +199,13 @@ func inviteToTeamCmd(cliCtx *cli.Context) error {
 		}
 	}
 
-	role, err := prompts.SelectRole()
-	if err != nil {
-		return prompts.HandleSelectError(err, "Could not select role")
+	role := cliCtx.String("role")
+
+	if role == "" {
+		role, err = prompts.SelectRole()
+		if err != nil {
+			return prompts.HandleSelectError(err, "Could not select role")
+		}
 	}
 
 	if err := inviteToTeam(ctx, team, email, name, role, client.Identity); err != nil {


### PR DESCRIPTION
This also allows to invite to a non-public role.