### PR TITLE
Fix regex user name to accept any unicode letter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- User display name accepts unicode letters
+
 ## [0.10.1] - 2017-11-15
 
 ### Fixed

--- a/prompts/prompts.go
+++ b/prompts/prompts.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	namePattern        = "^[a-zA-Z\\s,\\.'\\-pL]{1,64}$"
+	namePattern        = "^[a-zA-Z\\s,\\.'\\pL]{1,64}$"
 	couponPattern      = "^[0-9A-Z]{1,128}$"
 	codePattern        = "^[0-9abcdefghjkmnpqrtuvwxyz]{16}$"
 	inviteTokenPattern = "^[a-zA-Z0-9_-]{52}$"

--- a/prompts/prompts.go
+++ b/prompts/prompts.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	namePattern        = "^[a-zA-Z\\s,\\.'\\pL]{1,64}$"
+	namePattern        = "^[a-zA-Z\\s,\\.'\\-\\pL]{1,64}$"
 	couponPattern      = "^[0-9A-Z]{1,128}$"
 	codePattern        = "^[0-9abcdefghjkmnpqrtuvwxyz]{16}$"
 	inviteTokenPattern = "^[a-zA-Z0-9_-]{52}$"


### PR DESCRIPTION
```
✔ Name: Lōūýß
✔ Email: luiz+1@manifold.co
✔ Password: ●●●●●●●●
```