### PR TITLE
Remove title prompt during resource, project and team creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 - Provision event from `create` command
-
-### Changed
+- Title prompt removed from Resource, Project and Team creation
 
 - GitHub identity -- user user:email scope for login and link
 

--- a/cmd/alias.go
+++ b/cmd/alias.go
@@ -26,7 +26,6 @@ func init() {
 		Action: middleware.Chain(middleware.EnsureSession, middleware.LoadDirPrefs,
 			middleware.LoadTeamPrefs, aliasCredentialCmd),
 		Flags: append(teamFlags, []cli.Flag{
-			titleFlag(),
 			projectFlag(),
 		}...),
 	}

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -39,7 +39,6 @@ func init() {
 			projectFlag(),
 			planFlag(),
 			regionFlag(),
-			titleFlag(),
 			cli.StringFlag{
 				Name:  "product",
 				Usage: "Create a resource for this product",
@@ -182,10 +181,11 @@ func create(cliCtx *cli.Context) error {
 		return cli.NewExitError("Could not create resource: "+err.Error(), -1)
 	}
 
-	resourceName, resourceTitle, err := promptNameAndTitle(cliCtx, &resourceID, "resource", true, true)
+	resourceName, err := promptName(cliCtx, &resourceID, "resource", true)
 	if err != nil {
 		return err
 	}
+	resourceTitle := resourceName
 
 	spin := prompts.NewSpinner(fmt.Sprintf("Creating %s", descriptor))
 	if !dontWait {

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -12,15 +12,6 @@ func formatFlag(defaultValue, description string) cli.Flag {
 	return placeholder.New("format, f", "FORMAT", description, defaultValue, "MANIFOLD_FORMAT", false)
 }
 
-func titleFlag() cli.Flag {
-	return cli.StringFlag{
-		Name:   "title",
-		Usage:  "Specify a title to be used",
-		Value:  "",
-		EnvVar: "MANIFOLD_TITLE",
-	}
-}
-
 func descriptionFlag() cli.Flag {
 	return cli.StringFlag{
 		Name:   "description, d",

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/urfave/cli"
 
@@ -73,20 +72,13 @@ var helpCommand = cli.Command{
 	},
 }
 
-// generateTitle makes a name capitalized and replace dashes with spaaces
-func generateTitle(name string) manifold.Name {
-	title := strings.Title(strings.Replace(name, "-", " ", -1))
-	return manifold.Name(title)
-}
-
-// promptNameAndTitle encapsulates the logic for accepting a name as the first
-// positional argument (optionally), and a title flag (optionally)
-// returning generated values accepted by the user
-func promptNameAndTitle(ctx *cli.Context, optionalID *manifold.ID, objectName string, shouldInferTitle, allowEmpty bool) (string, string, error) {
+// promptName encapsulates the logic for accepting a name as the first
+// positional argument (optionally), and returning the appropriate value
+func promptName(ctx *cli.Context, optionalID *manifold.ID, objectName string, allowEmpty bool) (string, error) {
 	// The user may supply a name value as the first positional arg
 	argName, err := optionalArgName(ctx, 0, "name")
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 	shouldAccept := true
 	if optionalID != nil {
@@ -97,41 +89,8 @@ func promptNameAndTitle(ctx *cli.Context, optionalID *manifold.ID, objectName st
 		shouldAccept = false
 	}
 
-	// The user may supply a title value from a flag, validate it
-	flagTitle := ctx.String("title")
-
-	// Create the title based on the name argument
-	return createNameAndTitle(ctx, objectName, argName, flagTitle, shouldInferTitle, shouldAccept, allowEmpty)
-}
-
-func createNameAndTitle(ctx *cli.Context, objectName, argName, flagTitle string, shouldInferTitle, shouldAccept, allowEmpty bool) (string, string, error) {
-	var name, title string
-
 	// If no name value is supplied, prompt for it
 	// otherwise validate the given value
 	shouldAcceptName := shouldAccept && argName != ""
-	nameValue, err := prompts.Name(objectName, argName, shouldAcceptName, allowEmpty)
-	if err != nil {
-		return name, title, err
-	}
-	name = nameValue
-
-	// We will automatically validate/accept a title given as flag
-	shouldAcceptTitle := shouldAccept && flagTitle != ""
-	// If we shouldn't infer the title, do not automatically accept a title value
-	if !shouldInferTitle {
-		shouldAcceptTitle = false
-	}
-	defaultTitle := flagTitle
-	if flagTitle == "" && shouldInferTitle {
-		// If no flag is present, we will infer the title from the validated name
-		defaultTitle = string(generateTitle(name))
-	}
-	titleValue, err := prompts.Title(objectName, defaultTitle, shouldAcceptTitle, allowEmpty)
-	if err != nil {
-		return name, title, err
-	}
-	title = titleValue
-
-	return name, title, nil
+	return prompts.Name(objectName, argName, shouldAcceptName, allowEmpty)
 }

--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -37,7 +37,7 @@ func init() {
 			{
 				Name:      "create",
 				Usage:     "Create a new project",
-				Flags:     append(teamFlags, titleFlag()),
+				Flags:     teamFlags,
 				ArgsUsage: "[project-name]",
 				Action: middleware.Chain(middleware.EnsureSession,
 					middleware.LoadTeamPrefs, createProjectCmd),
@@ -56,7 +56,7 @@ func init() {
 				Name:  "update",
 				Usage: "Update an existing project",
 				Flags: append(teamFlags, []cli.Flag{
-					titleFlag(), descriptionFlag(),
+					descriptionFlag(),
 				}...),
 				ArgsUsage: "[project-name]",
 				Action: middleware.Chain(middleware.EnsureSession, middleware.LoadTeamPrefs,
@@ -116,10 +116,11 @@ func createProjectCmd(cliCtx *cli.Context) error {
 		return errUserActionAsTeam
 	}
 
-	projectName, projectTitle, err := promptNameAndTitle(cliCtx, nil, "project", true, false)
+	projectName, err := promptName(cliCtx, nil, "project", false)
 	if err != nil {
 		return err
 	}
+	projectTitle := projectName
 
 	params := projectClient.NewPostProjectsParamsWithContext(ctx)
 	body := &mModels.CreateProjectBody{
@@ -214,14 +215,11 @@ func updateProjectCmd(cliCtx *cli.Context) error {
 		return err
 	}
 
-	providedTitle := cliCtx.String("title")
-	if providedTitle == "" {
-		providedTitle = string(p.Body.Name)
-	}
-	newName, newTitle, err := createNameAndTitle(cliCtx, "project", string(p.Body.Label), providedTitle, true, false, false)
+	newName, err := promptName(cliCtx, nil, "project", false)
 	if err != nil {
 		return err
 	}
+	newTitle := newName
 
 	projectDescription := cliCtx.String("description")
 	autoSelectDescription := projectDescription != ""
@@ -257,7 +255,7 @@ func updateProjectCmd(cliCtx *cli.Context) error {
 	}
 
 	spin.Stop()
-	fmt.Printf("\nYour project \"%s\" has been updated\n", newTitle)
+	fmt.Printf("\nYour project \"%s\" has been updated\n", newName)
 	return nil
 }
 

--- a/cmd/teams.go
+++ b/cmd/teams.go
@@ -41,10 +41,7 @@ func init() {
 				Name:      "update",
 				Usage:     "Update an existing team",
 				ArgsUsage: "[team-name]",
-				Flags: []cli.Flag{
-					titleFlag(),
-				},
-				Action: middleware.Chain(middleware.EnsureSession, updateTeamCmd),
+				Action:    middleware.Chain(middleware.EnsureSession, updateTeamCmd),
 			},
 			{
 				Name:      "remove",
@@ -108,10 +105,11 @@ func createTeamCmd(cliCtx *cli.Context) error {
 		return err
 	}
 
-	teamName, teamTitle, err := promptNameAndTitle(cliCtx, nil, "team", true, false)
+	teamName, err := promptName(cliCtx, nil, "team", false)
 	if err != nil {
 		return err
 	}
+	teamTitle := teamName
 
 	client, err := api.New(api.Identity)
 	if err != nil {
@@ -148,20 +146,17 @@ func updateTeamCmd(cliCtx *cli.Context) error {
 		return err
 	}
 
-	providedTitle := cliCtx.String("title")
-	if providedTitle == "" {
-		providedTitle = string(team.Body.Name)
-	}
-	newName, newTitle, err := createNameAndTitle(cliCtx, "team", string(team.Body.Label), providedTitle, true, false, false)
+	newName, err := promptName(cliCtx, nil, "team", false)
 	if err != nil {
 		return err
 	}
+	newTitle := newName
 
 	if err := updateTeam(ctx, team, newName, newTitle, client.Identity); err != nil {
 		return cli.NewExitError(fmt.Sprintf("Could not update team: %s", err), -1)
 	}
 
-	fmt.Printf("Your team \"%s\" has been updated\n", newTitle)
+	fmt.Printf("Your team \"%s\" has been updated\n", newName)
 	return nil
 }
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -27,7 +27,6 @@ func init() {
 		Action: middleware.Chain(middleware.EnsureSession, middleware.LoadDirPrefs,
 			middleware.LoadTeamPrefs, updateResourceCmd),
 		Flags: append(teamFlags, []cli.Flag{
-			titleFlag(),
 			projectFlag(),
 		}...),
 	}
@@ -96,14 +95,11 @@ func updateResourceCmd(cliCtx *cli.Context) error {
 		resource = resources[idx]
 	}
 
-	providedTitle := cliCtx.String("title")
-	if providedTitle == "" {
-		providedTitle = string(resource.Body.Name)
-	}
-	newName, newTitle, err := createNameAndTitle(cliCtx, "resource", string(resource.Body.Label), providedTitle, true, false, false)
+	newName, err := promptName(cliCtx, nil, "resource", false)
 	if err != nil {
 		cli.NewExitError(fmt.Sprintf("Could not rename the resource: %s", err), -1)
 	}
+	newTitle := newName
 
 	prompts.SpinStart(fmt.Sprintf("Updating resource %q", resource.Body.Label))
 

--- a/prompts/prompts.go
+++ b/prompts/prompts.go
@@ -30,44 +30,6 @@ const NumberMask = '#'
 
 var errBad = errors.New("Bad Value")
 
-// Title prompts the user to provide a Title value
-func Title(field, defaultValue string, autoSelect, allowEmpty bool) (string, error) {
-	field = strings.Title(field)
-
-	validate := func(input string) error {
-		if allowEmpty && len(input) == 0 {
-			return nil
-		}
-
-		t := manifold.Name(input)
-		if err := t.Validate(nil); err != nil {
-			return fmt.Errorf("Please provide a valid %s title", field)
-		}
-
-		return nil
-	}
-
-	label := fmt.Sprintf("New %s Title", field)
-
-	if autoSelect {
-		err := validate(defaultValue)
-		if err != nil {
-			fmt.Println(templates.PromptFailure(label, defaultValue))
-		} else {
-			fmt.Println(templates.PromptSuccess(label, defaultValue))
-		}
-		return defaultValue, err
-	}
-
-	p := promptui.Prompt{
-		Label:    label,
-		Default:  defaultValue,
-		Validate: validate,
-	}
-
-	return p.Run()
-}
-
 // Name prompts the user to provide a Name value
 func Name(field, defaultValue string, autoSelect, allowEmpty bool) (string, error) {
 	field = strings.Title(field)
@@ -107,25 +69,9 @@ func Name(field, defaultValue string, autoSelect, allowEmpty bool) (string, erro
 	return p.Run()
 }
 
-// ResourceTitle prompts the user to provide a resource title or to accept empty
-// to let the system generate one.
-func ResourceTitle(defaultValue string, autoSelect bool) (string, error) {
-	return Title("resource", defaultValue, autoSelect, true)
-}
-
 // ResourceName prompts the user to provide a label name
 func ResourceName(defaultValue string, autoSelect bool) (string, error) {
 	return Name("resource", defaultValue, autoSelect, false)
-}
-
-// TeamTitle prompts the user to enter a new Team title
-func TeamTitle(defaultValue string, autoSelect bool) (string, error) {
-	return Title("team", defaultValue, autoSelect, false)
-}
-
-// ProjectTitle prompts the user to enter a new project title
-func ProjectTitle(defaultValue string, autoSelect bool) (string, error) {
-	return Title("project", defaultValue, autoSelect, false)
 }
 
 // TokenDescription prompts the user to enter a token description


### PR DESCRIPTION
We've decided in the dashboard that we will no longer employ the Title field on resources, projects and teams. So for the CLI this means no longer prompting for that value.

We will, for the short term, default the Title to the name value until the corresponding removal of that field occurs on the server.