### PR TITLE
Add base `manifold stack init` command

### DIFF
--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"github.com/urfave/cli"
+	"github.com/manifoldco/manifold-cli/middleware"
+
+	"github.com/manifoldco/manifold-cli/cmd/stack"
+)
+
+
+func init() {
+	stackCmd := cli.Command{
+		Name: "stack",
+		Usage: "Organize project resources into Stacks",
+		Category: "RESOURCES",
+		Subcommands: []cli.Command{
+			{
+				Name: "init",
+				Usage: "Initialize a new stack.yaml",
+				Flags: append(teamFlags, []cli.Flag{
+					cli.StringFlag{
+						Name: "project, p",
+						Usage: "Set a project name in your stack",
+					},
+					cli.BoolFlag{
+						Name: "generate, g",
+						Usage: "Auto-generate a new stack.yaml based on existing resource",
+					},
+					yesFlag(),
+				}...),
+				Action: middleware.Chain(middleware.EnsureSession, middleware.LoadTeamPrefs, stack.Init),
+			},
+		},
+	}
+
+	cmds = append(cmds, stackCmd)
+}
+

--- a/cmd/stack/init.go
+++ b/cmd/stack/init.go
@@ -1,0 +1,47 @@
+package stack
+
+import (
+	"io/ioutil"
+	"os"
+	"fmt"
+
+	"gopkg.in/yaml.v2"
+	"github.com/urfave/cli"
+
+	"github.com/manifoldco/manifold-cli/prompts"
+)
+
+func Init(cliCtx *cli.Context) error {
+	yes := cliCtx.Bool("yes")
+
+	existing, err := ioutil.ReadFile("stack.yaml");
+	if err != nil && !os.IsNotExist(err) || err == nil && len(existing) != 0 {
+		if !yes {
+			_, err := prompts.Confirm("Overwrite stack.yaml?")
+			if err != nil {
+				return cli.NewExitError("Not overwriting stack.yaml", -1)
+			}
+		}
+	}
+
+	projectTitle, err := prompts.ProjectTitle("", false)
+	if err != nil {
+		cli.NewExitError(fmt.Sprintf("Unable to save project name: %s", err), -1)
+	}
+
+	stack := StackYaml{
+		Project: projectTitle,
+	}
+
+	data, err := yaml.Marshal(stack)
+	if err != nil {
+		return cli.NewExitError(fmt.Sprintf("Unable to marshal YAML data: %s", err), -1)
+	}
+
+	err = ioutil.WriteFile("stack.yaml", data, 0644)
+	if err != nil {
+		return cli.NewExitError(fmt.Sprintf("Unable to save stack.yaml file"), -1)
+	}
+
+	return nil
+}

--- a/cmd/stack/stack.go
+++ b/cmd/stack/stack.go
@@ -1,0 +1,23 @@
+package stack
+
+// StackYaml defines the struct definition for the decoded stack.yaml
+type StackYaml struct {
+	// Project is a project label the defines the project that this stack belongs to
+	Project string `yaml:"project"`
+
+	// Resources are the Manifold-defined resources in the stack
+	Resources []StackResource `yaml:"resources,flow"`
+}
+
+// StackResource defines a single resource definition for the a stack, and defines resource
+// properties for the stack
+type StackResource struct {
+	// Resource it the label of the resource for this element in the stack
+	Resource string `yaml:"resource"`
+
+	// Product is the label of the Product for this element in the stack
+	Product string `yaml:"product"`
+
+	// Plan is the label of the Plan the resource should use
+	Plan string `yaml:"plan"`
+}

--- a/cmd/stack/stack.go
+++ b/cmd/stack/stack.go
@@ -6,15 +6,12 @@ type StackYaml struct {
 	Project string `yaml:"project"`
 
 	// Resources are the Manifold-defined resources in the stack
-	Resources []StackResource `yaml:"resources,flow"`
+	Resources map[string]StackResource `yaml:"resources,flow"`
 }
 
 // StackResource defines a single resource definition for the a stack, and defines resource
 // properties for the stack
 type StackResource struct {
-	// Resource it the label of the resource for this element in the stack
-	Resource string `yaml:"resource"`
-
 	// Product is the label of the Product for this element in the stack
 	Product string `yaml:"product"`
 


### PR DESCRIPTION
Adds `manifold stack init` for initializing a stack set in a project directory with a basic stack.yaml (that defines a project) 