### PR TITLE
Fix non-interactive resource creation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -85,8 +85,8 @@ func promptName(ctx *cli.Context, optionalID *manifold.ID, objectName string, al
 		_, name := names.New(*optionalID)
 		if argName == "" {
 			argName = string(name)
+			shouldAccept = false
 		}
-		shouldAccept = false
 	}
 
 	// If no name value is supplied, prompt for it


### PR DESCRIPTION
If the name is empty, we generated one, otherwise we used the provided and can continue non-interactively