### PR TITLE
Remove Transfer and Move analytics tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Panic when creating a custom resource
 - Using `--me` flag when a team is already set in `.manifold.yaml`
 
+## Removed
+
+- Moved Transfer and Move analytics to the backend
+
 ## [0.15.0] - 2018-07-18
 
 ### Added

--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -417,16 +417,6 @@ func addProjectCmd(cliCtx *cli.Context) error {
 		fmt.Printf("Moving %s to %s\n", r.Body.Label, p.Body.Label)
 	}
 
-	params := map[string]string{
-		"resource_id":    r.ID.String(),
-		"resource_name":  string(r.Body.Name),
-		"resource_label": string(r.Body.Label),
-		"project_id":     p.ID.String(),
-		"project_name":   string(p.Body.Name),
-		"project_label":  string(p.Body.Label),
-	}
-	client.Analytics.Track(ctx, "Added a Resource to a Project", &params)
-
 	return nil
 }
 
@@ -493,13 +483,6 @@ func removeProjectCmd(cliCtx *cli.Context) error {
 	}
 
 	fmt.Printf("Removed %s from project\n", r.Body.Label)
-
-	params := map[string]string{
-		"resource_id":    r.ID.String(),
-		"resource_name":  string(r.Body.Name),
-		"resource_label": string(r.Body.Label),
-	}
-	client.Analytics.Track(ctx, "Removed a Resource from a Project", &params)
 
 	return nil
 }

--- a/cmd/transfer.go
+++ b/cmd/transfer.go
@@ -214,8 +214,6 @@ func transferResource(ctx context.Context, client *api.API,
 		}
 	}
 
-	client.Analytics.Track(ctx, "Transfer Operation", &map[string]string{})
-
 	if dontWait {
 		return nil
 	}


### PR DESCRIPTION
Transfer and Move analytics has been moved to the backend

Resolves manifoldco/engineering#5361