### PR TITLE
Fix panic for resource name prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Fixed
+
+- Panic when creating a custom resource
+
 ## [0.15.0] - 2018-07-18
 
 ### Added

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -188,7 +188,13 @@ func create(cliCtx *cli.Context) error {
 		return cli.NewExitError("Could not create resource: "+err.Error(), -1)
 	}
 
-	resourceName, err := promptNameForResource(cliCtx, &resourceID, product.Body.Label)
+	prefix := manifold.Label("custom")
+
+	if product != nil {
+		prefix = product.Body.Label
+	}
+
+	resourceName, err := promptNameForResource(cliCtx, &resourceID, prefix)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Before:

```
manifold create --custom
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x8d5e69]
goroutine 1 [running]:
main.create(0xc42009a2c0, 0x0, 0x0)
        /home/luiz/go/src/github.com/manifoldco/manifold-cli/cmd/create.go:191 +0x8b9
```

After:

```
./bin/manifold create --custom
✔ New Resource Name: custom-cultivated-palatinate-purple-semicircle
```