### PR TITLE
Ignore team from .yaml if --me flag is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Fixed
+
+- Using `--me` flag when a team is already set in `.manifold.yaml`
+
 ## [0.15.0] - 2018-07-18
 
 ### Added

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -164,7 +164,7 @@ func reflectArgs(ctx *cli.Context, i interface{}, tagName string) error {
 	flags := make(map[string]bool)
 	for _, flagName := range ctx.FlagNames() {
 		// This value is already set via arguments or env vars. skip it.
-		if isSet(ctx, flagName) {
+		if isSet(ctx, flagName) || (ctx.IsSet("me") && flagName == "team") {
 			continue
 		}
 


### PR DESCRIPTION
## With a team inside .yaml

Before:
```
manifold create --me
Cannot use --me with --team
```

After:
```
./bin/manifold create --me
Use the arrow keys to navigate: ↓ ↑ → ←  and / toggles search
? Select Product:
```