### PR TITLE
Check manifoldrc existence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Fix
+
+- `.manifoldrc` permission check for Windows
+
 ## [0.15.0] - 2018-07-18
 
 ### Added


### PR DESCRIPTION
Instead of checking using Unix permission bits, try to read or create `.manifoldrc` instead.

Closes: https://github.com/manifoldco/manifold-cli/issues/223