### PR TITLE
Fix root detection for windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Panic when creating a custom resource
-- Using `--me` flag when a team is already set in `.manifold.yaml`
+- Using `--me` flag when a team is already set in `.manifold.yml`
 - `.manifoldrc` permission check for Windows
+- Root detection on Windows when trying to find `.manifold.yml`
 
 ## Removed
 

--- a/config/config.go
+++ b/config/config.go
@@ -36,7 +36,6 @@ const (
 	defaultScheme       = "https"
 	defaultAnalytics    = true
 	rcFilename          = ".manifoldrc"
-	rootPathLength      = 1
 	// YamlFilename is where dirprefs are stored
 	YamlFilename = ".manifold.yml"
 )
@@ -280,11 +279,13 @@ func LoadYaml(recurse bool) (*ManifoldYaml, error) {
 	for {
 		f, err = os.Open(filepath.Join(path, YamlFilename))
 		if err != nil {
-			if isSystemRoot(path) || !recurse {
+			newPath := filepath.Dir(path)
+
+			if path == newPath || !recurse {
 				return prefs, nil
 			}
 
-			path = filepath.Dir(path)
+			path = newPath
 			continue
 		}
 
@@ -304,16 +305,6 @@ func LoadYaml(recurse bool) (*ManifoldYaml, error) {
 
 	prefs.Path = f.Name()
 	return prefs, nil
-}
-
-// isSystemRoot validates if the given path is the root of the system for the
-// OS the application is running on.
-func isSystemRoot(path string) bool {
-	if len(path) != rootPathLength {
-		return false
-	}
-
-	return os.PathSeparator == path[rootPathLength-1]
 }
 
 func UserHome() (string, error) {


### PR DESCRIPTION
If the parent of the current directory is itself, we assume we can't go any further and stop trying to find a `.manifold.yml` file.